### PR TITLE
chore: bump @efcnewlife/newlife-ui to ^0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@azure/msal-browser": "^4.12.0",
-    "@efcnewlife/newlife-ui": "^0.3.2",
+    "@efcnewlife/newlife-ui": "^0.3.3",
     "@tailwindcss/forms": "^0.5.10",
     "axios": "^1.11.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.12.0
         version: 4.30.0
       '@efcnewlife/newlife-ui':
-        specifier: ^0.3.2
-        version: 0.3.2(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react-icons@5.5.0(react@19.2.4))(react@19.2.4)
+        specifier: ^0.3.3
+        version: 0.3.3(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react-icons@5.5.0(react@19.2.4))(react@19.2.4)
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.11(tailwindcss@4.1.18)
@@ -204,6 +204,10 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -243,8 +247,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@efcnewlife/newlife-ui@0.3.2':
-    resolution: {integrity: sha512-x/zU0UeGlY/dmdQGKFw1LXTTv/Zr1Xg1rYt2FCyP9E/IKRYM4HMht7Lvj2psHYymLAeyQ64N7sJLq1S/YRpW7w==, tarball: https://npm.pkg.github.com/download/@efcnewlife/newlife-ui/0.3.2/d9a24d9dd0cbd13ae6fe1c0d2111aecd35938c87}
+  '@efcnewlife/newlife-ui@0.3.3':
+    resolution: {integrity: sha512-goDCHmaVkrvtXyXqPdcRmc6ZdruSJ0CoIwq4kVbBz6ZDLD/HnXxP6ouifcM4UNXU8sCOzQkyfJrbhHfEwFmtZw==, tarball: https://npm.pkg.github.com/download/@efcnewlife/newlife-ui/0.3.3/c5709996aeedf01e9c07c11c189ebb619332e258}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -1734,6 +1738,9 @@ packages:
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
@@ -2009,6 +2016,8 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2034,7 +2043,7 @@ snapshots:
 
   '@base-ui/react@1.7.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@base-ui/utils': 0.3.2(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/utils': 0.2.12
@@ -2046,7 +2055,7 @@ snapshots:
 
   '@base-ui/utils@0.3.2(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -2055,7 +2064,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.13
 
-  '@efcnewlife/newlife-ui@0.3.2(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react-icons@5.5.0(react@19.2.4))(react@19.2.4)':
+  '@efcnewlife/newlife-ui@0.3.3(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react-icons@5.5.0(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@base-ui/react': 1.7.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
@@ -2063,7 +2072,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-icons: 5.5.0(react@19.2.4)
-      tailwind-merge: 3.4.0
+      tailwind-merge: 3.6.0
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@types/react'
@@ -3396,6 +3405,8 @@ snapshots:
   svg-parser@2.0.4: {}
 
   tailwind-merge@3.4.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.1.18: {}
 


### PR DESCRIPTION
## Summary

Bump `@efcnewlife/newlife-ui` to `^0.3.3` so Portal picks up Time/DateTime field wall-clock text that follows host `ampm`. Existing Portal TimePicker / DateTimePicker call sites keep explicit `ampm`; no library default change.

Closes #6

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [x] Dependency or tooling

## Implementation notes

- Host owns 12-hour convention via explicit `ampm` props (library default remains `ampm=false`).
- Diff is dependency metadata only (`package.json` + `pnpm-lock.yaml`).

## Testing

- [x] Installed package version resolves to `0.3.3`
- [x] `./node_modules/.bin/tsc -b --noEmit`
- [ ] `pnpm run type-check` (CI; local install may need valid `NODE_AUTH_TOKEN` / Packages read)

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)