### PR TITLE
feat: add DataTable row hover and selected row backgrounds

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,3 +11,15 @@ _Avoid_: DateRangePicker as the default control for these fields, treating an op
 **Booking start / Booking end**:
 The start and end instants of a facility booking (`startAt` / `endAt` on the API as UTC ISO). The admin UI edits them as date-and-time values with a display timezone, not as date-only or time-only fields.
 _Avoid_: calendar-date-only booking, wall-clock string as the domain meaning of the instant
+
+**DataTable**:
+The Portal admin list shell built on `@efcnewlife/newlife-ui` Table primitives, plus pagination, sorting, row selection, and context menu. It is a host composite, not the library Table itself.
+_Avoid_: Table (when meaning the Portal list page), DataGrid, Grid
+
+**Table row hover**:
+Transient visual emphasis on a DataTable data row while the pointer is over that row. It is affordance only and does not mean the row is selected.
+_Avoid_: row highlight as selection, hover action / hover callback as the default meaning of hover
+
+**Selected row**:
+A DataTable data row that is currently in the selection set (checkbox multi-select or programmed selection keys). Selection is persistent until cleared; table row hover may stack on top of it.
+_Avoid_: treating hover as selection, confusing sticky header chrome with selection

--- a/src/components/DataPage/DataPage.tsx
+++ b/src/components/DataPage/DataPage.tsx
@@ -31,6 +31,8 @@ interface DataPageProps<T extends Record<string, unknown>> {
   onItemsPerPageChange?: (pageSize: number) => void;
   /** Container style class name */
   className?: string;
+  /** Whether data rows show table row hover (default true) */
+  rowHover?: boolean;
   /** Callback to clear selected state */
   onClearSelectionRef?: (clearFn: () => void) => void;
   /** Function to get reordering information */
@@ -64,6 +66,7 @@ export default function DataPage<T extends Record<string, unknown>>({
   onPageChange,
   onItemsPerPageChange,
   className,
+  rowHover = true,
   onClearSelectionRef,
   getReorderInfo,
   onReorder,
@@ -84,6 +87,7 @@ export default function DataPage<T extends Record<string, unknown>>({
           onSort={onSort}
           onRowSelect={onRowSelect}
           rowActions={rowActions}
+          rowHover={rowHover}
           onClearSelectionRef={onClearSelectionRef}
           getReorderInfo={getReorderInfo}
           onReorder={onReorder}

--- a/src/components/DataPage/DataTable.tsx
+++ b/src/components/DataPage/DataTable.tsx
@@ -26,6 +26,7 @@ export default function DataTable<T extends Record<string, unknown>>({
   className,
   headerClassName,
   rowClassName,
+  rowHover = true,
   rowKey = "id",
   onClearSelectionRef,
   getReorderInfo,
@@ -362,6 +363,7 @@ export default function DataTable<T extends Record<string, unknown>>({
             onRowContextMenu={handleRowContextMenu}
             rowKey={rowKey}
             rowClassName={rowClassName}
+            rowHover={rowHover}
             loading={loading}
             emptyMessage={emptyMessage}
             expandedKeys={expandedKeys}

--- a/src/components/DataPage/DataTableBody.tsx
+++ b/src/components/DataPage/DataTableBody.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, Spinner, TableBody, TableCell, TableRow, Tooltip } from "@efcnewlife/newlife-ui";
 import { Fragment } from "react";
+import { getDataTableRowClassName } from "./getDataTableRowClassName";
 import { DataTableColumn } from "./types";
 
 interface DataTableBodyProps<T> {
@@ -21,6 +22,8 @@ interface DataTableBodyProps<T> {
   rowKey?: keyof T | ((row: T) => string);
   /** Row CSS class name */
   rowClassName?: string;
+  /** Whether data rows show table row hover (default true) */
+  rowHover?: boolean;
   /** Loading state */
   loading?: boolean;
   /** Empty-data message */
@@ -40,6 +43,7 @@ export default function DataTableBody<T extends Record<string, unknown>>({
   onRowContextMenu,
   rowKey = "id",
   rowClassName,
+  rowHover = true,
   loading = false,
   emptyMessage = "No data available",
   expandedKeys,
@@ -170,7 +174,11 @@ export default function DataTableBody<T extends Record<string, unknown>>({
         return (
           <Fragment key={key}>
             <TableRow
-              className={`border-l border-b border-gray-100 dark:border-white/[0.05] ${rowClassName}`}
+              className={getDataTableRowClassName({
+                isSelected,
+                rowHover,
+                rowClassName,
+              })}
               onContextMenu={(e: React.MouseEvent<HTMLTableRowElement>) => onRowContextMenu?.(row, index, e)}
             >
               {/* Selection column */}

--- a/src/components/DataPage/getDataTableRowClassName.test.ts
+++ b/src/components/DataPage/getDataTableRowClassName.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getDataTableRowClassName } from "./getDataTableRowClassName";
+
+describe("getDataTableRowClassName", () => {
+  it("adds neutral hover when the row is not selected and row hover is on", () => {
+    const className = getDataTableRowClassName({ isSelected: false, rowHover: true });
+    expect(className).toContain("hover:bg-surface-variant");
+    expect(className).toContain("transition-colors");
+    expect(className).not.toContain("bg-primary-container/40");
+  });
+
+  it("adds selected background and selected hover when selected and row hover is on", () => {
+    const className = getDataTableRowClassName({ isSelected: true, rowHover: true });
+    expect(className).toContain("bg-primary-container/40");
+    expect(className).toContain("hover:bg-primary-container/60");
+    expect(className).not.toContain("hover:bg-surface-variant");
+  });
+
+  it("omits hover utilities when row hover is off", () => {
+    const className = getDataTableRowClassName({ isSelected: false, rowHover: false });
+    expect(className).not.toContain("hover:bg-surface-variant");
+    expect(className).not.toContain("hover:bg-primary-container/60");
+  });
+
+  it("keeps selected background when row hover is off", () => {
+    const className = getDataTableRowClassName({ isSelected: true, rowHover: false });
+    expect(className).toContain("bg-primary-container/40");
+    expect(className).not.toContain("hover:bg-primary-container/60");
+    expect(className).not.toContain("hover:bg-surface-variant");
+  });
+
+  it("merges rowClassName with built-in row state classes", () => {
+    const className = getDataTableRowClassName({
+      isSelected: false,
+      rowHover: true,
+      rowClassName: "custom-row",
+    });
+    expect(className).toContain("custom-row");
+    expect(className).toContain("hover:bg-surface-variant");
+  });
+});

--- a/src/components/DataPage/getDataTableRowClassName.ts
+++ b/src/components/DataPage/getDataTableRowClassName.ts
@@ -1,0 +1,23 @@
+import { cn } from "@/utils";
+
+export interface GetDataTableRowClassNameOptions {
+  isSelected: boolean;
+  rowHover: boolean;
+  rowClassName?: string;
+}
+
+const DATA_ROW_BASE_CLASS =
+  "border-l border-b border-gray-100 dark:border-white/[0.05] transition-colors";
+
+export function getDataTableRowClassName({
+  isSelected,
+  rowHover,
+  rowClassName,
+}: GetDataTableRowClassNameOptions): string {
+  return cn(
+    DATA_ROW_BASE_CLASS,
+    isSelected && "bg-primary-container/40",
+    rowHover && (isSelected ? "hover:bg-primary-container/60" : "hover:bg-surface-variant"),
+    rowClassName,
+  );
+}

--- a/src/components/DataPage/types/index.ts
+++ b/src/components/DataPage/types/index.ts
@@ -105,6 +105,8 @@ export interface DataTableProps<T> {
   headerClassName?: string;
   /** Row CSS class name */
   rowClassName?: string;
+  /** Whether data rows show table row hover (default true) */
+  rowHover?: boolean;
   /** Row key */
   rowKey?: keyof T | ((row: T) => string);
   /** Callback for clearing selection */


### PR DESCRIPTION
## Summary

Adds table row hover and selected-row background stacking on Portal DataTable data rows (M3 role utilities), with an optional `rowHover` opt-out forwarded through DataPage. Closes #5.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Pure seam `getDataTableRowClassName` composes base borders, `transition-colors`, unselected hover (`hover:bg-surface-variant`), selected (`bg-primary-container/40`), and selected+hover (`hover:bg-primary-container/60`).
- Applied only to data rows; loading, empty, expand-detail, and sticky header rows are unchanged.
- Glossary updates in `CONTEXT.md` for DataTable, table row hover, and selected row.
- Does not change `@efcnewlife/newlife-ui` Table defaults or conf-portal.

## Testing

- [x] `pnpm run test`
- [x] `pnpm run type-check`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge