### PR TITLE
feat: display portal datetime in 12-hour AM/PM

### DIFF
--- a/src/pages/Content/File/FileTableList.tsx
+++ b/src/pages/Content/File/FileTableList.tsx
@@ -68,7 +68,7 @@ const FileTableList = ({ files, selectedKeys, onSelect, onDeleteOne }: FileTable
                   {file.size !== undefined ? formatBytes(file.size) : "-"}
                 </td>
                 <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
-                  {file.createdAt ? DateUtil.format(file.createdAt, "YYYY-MM-DD HH:mm") : "-"}
+                  {file.createdAt ? DateUtil.format(file.createdAt) : "-"}
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex items-center justify-end gap-2">

--- a/src/pages/Facility/Booking/BookingDataForm.tsx
+++ b/src/pages/Facility/Booking/BookingDataForm.tsx
@@ -6,6 +6,7 @@ import {
 import ministryService, { type MinistryListItem } from "@/api/services/ministryService";
 import userService, { type UserBase } from "@/api/services/userService";
 import { usePickerLabels } from "@/hooks/usePickerLabels";
+import { DateUtil } from "@/utils/dateUtil";
 import { getLocalTimezone } from "@/utils/dayjsApi";
 import { Button, Checkbox, ComboBox, DateTimePicker, Select, TextArea } from "@efcnewlife/newlife-ui";
 import type { Dayjs } from "dayjs";
@@ -316,6 +317,7 @@ const BookingDataForm = forwardRef<BookingDataFormHandle, Props>(function Bookin
         timezone={displayTimezone}
         minuteStep={15}
         ampm
+        format={DateUtil.DATETIME_DISPLAY_FORMAT}
         showSubmitButton={false}
         labels={pickerLabels}
         error={errors.startAt}
@@ -329,6 +331,7 @@ const BookingDataForm = forwardRef<BookingDataFormHandle, Props>(function Bookin
         timezone={displayTimezone}
         minuteStep={15}
         ampm
+        format={DateUtil.DATETIME_DISPLAY_FORMAT}
         showSubmitButton={false}
         labels={pickerLabels}
         error={errors.endAt}

--- a/src/pages/Org/Position/PositionDataPage.tsx
+++ b/src/pages/Org/Position/PositionDataPage.tsx
@@ -2,6 +2,7 @@ import { orgService, type PositionDetail } from "@/api/services/orgService";
 import { userService } from "@/api/services/userService";
 import type { DataTableColumn, MenuButtonType, PageButtonType } from "@/components/DataPage";
 import { CommonPageButton, CommonRowAction, DataPage } from "@/components/DataPage";
+import { DateUtil } from "@/utils/dateUtil";
 import { dayjsToApiUtcIso, getLocalTimezone } from "@/utils/dayjsApi";
 import { Button, DateTimePicker, Modal, ModalForm, Select } from "@efcnewlife/newlife-ui";
 import { Resource, Verb } from "@/const/enums";
@@ -266,6 +267,7 @@ const PositionDataPage = () => {
             onChange={(value) => setAssignStartAt(value)}
             timezone={displayTimezone}
             ampm
+            format={DateUtil.DATETIME_DISPLAY_FORMAT}
             showSubmitButton={false}
             labels={pickerLabels}
           />

--- a/src/utils/dateUtil.test.ts
+++ b/src/utils/dateUtil.test.ts
@@ -20,11 +20,18 @@ describe("DateUtil display contract", () => {
 
   describe("format", () => {
     it("formats a valid wall-clock datetime with the default pattern", () => {
-      expect(DateUtil.format("2026-03-15 14:30")).toBe("2026-03-15 14:30");
+      expect(DateUtil.format("2026-03-15 14:30")).toBe("2026-03-15 02:30 PM");
     });
 
     it("formats an ISO local datetime as wall-clock with the default pattern", () => {
-      expect(DateUtil.format("2026-03-15T14:30:00")).toBe("2026-03-15 14:30");
+      expect(DateUtil.format("2026-03-15T14:30:00")).toBe("2026-03-15 02:30 PM");
+    });
+
+    it("uses DATETIME_DISPLAY_FORMAT when the pattern is omitted", () => {
+      expect(DateUtil.DATETIME_DISPLAY_FORMAT).toBe("YYYY-MM-DD hh:mm A");
+      expect(DateUtil.format("2026-03-15 14:30")).toBe(
+        DateUtil.format("2026-03-15 14:30", DateUtil.DATETIME_DISPLAY_FORMAT)
+      );
     });
 
     it("formats a valid datetime with a custom pattern", () => {

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -14,13 +14,15 @@ const parseDisplayDate = (date: unknown) => {
  * `@/i18n` (`sync_dayjs_locale`) so `fromNow()` matches UI language.
  */
 export class DateUtil {
+  static readonly DATETIME_DISPLAY_FORMAT = "YYYY-MM-DD hh:mm A";
+
   /**
    * Format date
    * @param date date value
-   * @param format Format string, default 'YYYY-MM-DD HH:mm'
+   * @param format Format string, default DATETIME_DISPLAY_FORMAT
    * @returns Formatted date string
    */
-  static format(date: unknown, format: string = "YYYY-MM-DD HH:mm"): string | undefined {
+  static format(date: unknown, format: string = DateUtil.DATETIME_DISPLAY_FORMAT): string | undefined {
     const parsed = parseDisplayDate(date);
     return parsed ? parsed.format(format) : undefined;
   }


### PR DESCRIPTION
## Summary

Show datetime values as `YYYY-MM-DD hh:mm A` across the Portal so lists, details, and ampm DateTimePickers use the same 12-hour clock. `DateUtil.format` now defaults to a shared `DATETIME_DISPLAY_FORMAT` constant; Booking and Position pickers pass that constant as display-only `format`.

Closes #10

## Type of change

- [x] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Time-of-day columns and TimePickers are unchanged.
- `friendlyDate` is unchanged; only `DateUtil.format` (including tooltips) switches clock.
- Library `@efcnewlife/newlife-ui` is not modified.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm run test`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)