### PR TITLE
feat: pack overlapping Calendar bookings into clickable lanes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 ### Custom
 .idea
 .vscode
-docs
+docs/*
+!docs/adr/
+!docs/adr/**
 
 ### Node template
 # Logs

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 docs/*
 !docs/adr/
 !docs/adr/**
+!docs/agents/
 
 ### Node template
 # Logs

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,8 @@ The Calendar view's unit is one booking: a single block keyed by booking id, sho
 _Avoid_: one block per room, duplicating the same booking across Calendar columns, treating Grid's Primary facility as the Calendar mapping rule
 
 **Calendar collision group**:
-Calendar booking events on the same day column that overlap through a chain of intervals (connected overlap). They are laid out in equal-width side-by-side lanes, with lane count computed per group (a solo event still spans the day column). Visible lanes are the first K from greedy packing (earliest Booking start, then latest Booking end). K is lower in week than in day. Each drawn Calendar booking event stays its own clickable block. Same-room overlap is a Scheduling Conflict and should not appear as confirmed events.
-_Avoid_: representative + `+N` list as the v1 Calendar layout, stacking full-width blocks, day-wide column count that shrinks unrelated later events, expanding a lane into empty neighbors, treating this as Grid occupancy, one lane per room
+Calendar booking events on the same day column that overlap through a chain of intervals (connected overlap). Greedy packing assigns columns; later columns overlay the earlier ones with a fixed left indent and flush to the day column's right edge (card stack). Column 0 stays full width. K is the max concurrent columns in the group (lower in week than in day). Each drawn Calendar booking event stays its own clickable block. Same-room overlap is a Scheduling Conflict and should not appear as confirmed events.
+_Avoid_: representative + `+N` list as the v1 Calendar layout, stacking full-width blocks with no indent, equal-width tiles that shrink a long booking for its whole duration, containment nesting boxes, treating this as Grid occupancy, one lane per room
 
 **Calendar density overflow**:
 The control on a Calendar collision group when the group needs more lanes than K. It shows how many events were not drawn and switches Booking view mode to `grid` for that date. It is not a list of the hidden bookings.

--- a/docs/adr/0001-calendar-concurrent-booking-lanes.md
+++ b/docs/adr/0001-calendar-concurrent-booking-lanes.md
@@ -1,0 +1,29 @@
+# 0001. Calendar concurrent booking lanes
+
+## Status
+
+Accepted
+
+## Context
+
+On the admin booking Calendar, overlapping Calendar booking events were drawn full-width in the day column. Later blocks covered earlier ones, so an operator could not see or click every booking in that time range.
+
+## Decision
+
+Lay out overlapping Calendar booking events in equal-width side-by-side lanes, one block per booking.
+
+- A Calendar collision group is a connected component of interval overlap on that local day. Intervals are half-open: `end <= other.start` is not overlap.
+- Pack columns with greedy assignment: sort by Booking start ascending, then Booking end descending; assign the leftmost column whose last end is `<=` this start.
+- Lane count and width are computed per group. Width is `1 / visibleLaneCount` of the day column, where `visibleLaneCount` is `min(columnsNeeded, K)` for that group only — never the max column count of the whole day. Do not expand a lane into empty neighbors.
+- Week passes `K = 4`. Day passes `K = 10`. The packer does not hard-code K.
+- Visible lanes are the first K from greedy packing. Events assigned column index `>= K` are omitted from the grid.
+- Calendar density overflow is a control on the collision group. Its label includes N (undrawn count for that group). Activating it switches Booking view mode to `grid` and sets `date` to that day column's ISO date. It does not open detail, a context menu, or a remainder list.
+- One Calendar booking event per booking id; title is the Booker. Cancelled bookings stay off Calendar. Midnight-spanning bookings continue across day columns, with packing computed per day.
+- Month view is unused by booking Calendar and stays as-is. List and Grid views are unchanged.
+
+## Consequences
+
+- Operators can click every drawn booking that still fits the lane cap.
+- A busy morning does not shrink an unrelated afternoon booking.
+- When a group exceeds K, Calendar is explicitly incomplete for that slot; Grid is the overflow destination.
+- Later work must not silently restore full-width stacking, a representative + remainder popover, day-wide column counts, or unlimited lane splitting.

--- a/docs/adr/0001-calendar-concurrent-booking-lanes.md
+++ b/docs/adr/0001-calendar-concurrent-booking-lanes.md
@@ -8,22 +8,26 @@ Accepted
 
 On the admin booking Calendar, overlapping Calendar booking events were drawn full-width in the day column. Later blocks covered earlier ones, so an operator could not see or click every booking in that time range.
 
+Equal-width columns for a whole collision group shrink every booking for its entire duration, even when a short booking only covers part of that span. Nesting contained intervals inside a parent box also diverges from Google Calendar's card-stack overlay.
+
 ## Decision
 
-Lay out overlapping Calendar booking events in equal-width side-by-side lanes, one block per booking.
+Lay out overlapping Calendar booking events as a right-aligned card stack: the earliest lane stays full width; later lanes overlay with a fixed left indent and flush to the day column's right edge.
 
-- A Calendar collision group is a connected component of interval overlap on that local day. Intervals are half-open: `end <= other.start` is not overlap.
-- Pack columns with greedy assignment: sort by Booking start ascending, then Booking end descending; assign the leftmost column whose last end is `<=` this start.
-- Lane count and width are computed per group. Width is `1 / visibleLaneCount` of the day column, where `visibleLaneCount` is `min(columnsNeeded, K)` for that group only — never the max column count of the whole day. Do not expand a lane into empty neighbors.
-- Week passes `K = 4`. Day passes `K = 10`. The packer does not hard-code K.
-- Visible lanes are the first K from greedy packing. Events assigned column index `>= K` are omitted from the grid.
-- Calendar density overflow is a control on the collision group. Its label includes N (undrawn count for that group). Activating it switches Booking view mode to `grid` and sets `date` to that day column's ISO date. It does not open detail, a context menu, or a remainder list.
+- A Calendar collision group is a connected component of interval overlap on one day column. Intervals are half-open: `end <= other.start` is not overlap.
+- Pack columns with greedy assignment: sort by start ascending, then end descending; assign the leftmost column whose last end is `<=` this start. There is no parent/child containment tree.
+- Horizontal geometry does not use column count `n`: `left = min(col * INDENT, 1 - MIN_WIDTH)`, `width = 1 - left`. Column 0 is always full width. Later columns share the same indent when they reuse a lane (back-to-back).
+- Do not expand into empty neighbor columns. Width stays constant for the event's whole duration.
+- Week passes `K = 4`. Day passes `K = 10`. K is the max concurrent columns in a collision group. The packer does not hard-code K.
+- Visible lanes are the first K from greedy packing. Events assigned column index `>= K` are omitted. Overflow layout still uses each visible event's real `col` for indent (not `col / n`).
+- Calendar density overflow is a control on that overflowing group. Its label includes N (undrawn count). Activating it switches Booking view mode to `grid` and sets `date` to that day column's ISO date. It does not open detail, a context menu, or a remainder list.
 - One Calendar booking event per booking id; title is the Booker. Cancelled bookings stay off Calendar. Midnight-spanning bookings continue across day columns, with packing computed per day.
 - Month view is unused by booking Calendar and stays as-is. List and Grid views are unchanged.
 
 ## Consequences
 
 - Operators can click every drawn booking that still fits the lane cap.
+- A long booking stays a full-width base card; shorter overlapping bookings stack on top with a slight left indent (Google Calendar-style overlay), not side-by-side equal tiles.
 - A busy morning does not shrink an unrelated afternoon booking.
 - When a group exceeds K, Calendar is explicitly incomplete for that slot; Grid is the overflow destination.
-- Later work must not silently restore full-width stacking, a representative + remainder popover, day-wide column counts, or unlimited lane splitting.
+- Later work must not silently restore full-width stacking without indent, a representative + remainder popover, equal-width day columns, or containment nesting boxes.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -16,6 +16,7 @@ const Calendar = ({
   onEventClick,
   onEventContextMenu,
   onAddEvent,
+  onDensityOverflow,
   showNavigationButtons = true,
 }: CalendarProps) => {
   const [selectedDate, setSelectedDate] = useState<Date>(currentDate);
@@ -121,6 +122,7 @@ const Calendar = ({
       onEventClick,
       onEventContextMenu,
       onAddEvent,
+      onDensityOverflow,
     };
 
     switch (currentView) {

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { MdAdd } from "react-icons/md";
 import { useTranslation } from "react-i18next";
+import { MdAdd } from "react-icons/md";
 import DensityOverflowControl from "./DensityOverflowControl";
 import EventBlock from "./EventBlock";
 import { packDayEventLanes } from "./packDayEventLanes";
@@ -168,17 +168,17 @@ const DayView = ({
               {timeSlots.map((slot) => {
                 const isLastSlot = slot.index === 47;
                 const top = slot.index * 48; // Each slot is 48px
-                
+
                 // Calculate start time for this slot (HH:mm format)
                 const startHour = slot.hour;
                 const startMinute = slot.isHalfHour ? 30 : 0;
                 const startTime = `${startHour.toString().padStart(2, "0")}:${startMinute.toString().padStart(2, "0")}`;
-                
+
                 // Calculate end time for this slot (30 minutes later, HH:mm format)
                 const endHour = slot.isHalfHour ? (slot.hour + 1) % 24 : slot.hour;
                 const endMinute = slot.isHalfHour ? 0 : 30;
                 const endTime = `${endHour.toString().padStart(2, "0")}:${endMinute.toString().padStart(2, "0")}`;
-                
+
                 return (
                   <div
                     key={slot.index}
@@ -236,6 +236,7 @@ const DayView = ({
                     horizontalLayout={{
                       leftPercent: placement.leftPercent,
                       widthPercent: placement.widthPercent,
+                      laneIndex: placement.laneIndex,
                     }}
                     onEventClick={onEventClick}
                     onContextMenu={onEventContextMenu}
@@ -276,9 +277,7 @@ const DayView = ({
               />
             </svg>
           </button>
-          <div className="flex-auto text-sm font-semibold">
-            {formatDate(miniCalendarMonth, "month-year", locale)}
-          </div>
+          <div className="flex-auto text-sm font-semibold">{formatDate(miniCalendarMonth, "month-year", locale)}</div>
           <button
             type="button"
             onClick={handleMiniCalendarNext}
@@ -306,7 +305,7 @@ const DayView = ({
             // Parse date string (YYYY-MM-DD) as local time
             const [year, month, dayNum] = day.date.split("-").map(Number);
             const dayDate = new Date(year, month - 1, dayNum);
-            
+
             // Normalize currentDate to local timezone for comparison
             const normalizedCurrentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
             const normalizedDayDate = new Date(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate());

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -1,11 +1,24 @@
 import { useEffect, useState } from "react";
 import { MdAdd } from "react-icons/md";
 import { useTranslation } from "react-i18next";
+import DensityOverflowControl from "./DensityOverflowControl";
 import EventBlock from "./EventBlock";
+import { packDayEventLanes } from "./packDayEventLanes";
 import { CalendarViewProps } from "./types";
 import { formatDate, getMonthDays, isDateInRange } from "./utils";
 
-const DayView = ({ currentDate, events = [], validRange, onEventClick, onDateChange, onEventContextMenu, onAddEvent }: CalendarViewProps) => {
+const DAY_MAX_EVENT_LANES = 10;
+
+const DayView = ({
+  currentDate,
+  events = [],
+  validRange,
+  onEventClick,
+  onDateChange,
+  onEventContextMenu,
+  onAddEvent,
+  onDensityOverflow,
+}: CalendarViewProps) => {
   const { t, i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
   // Filter events that overlap with the current day (including multi-day events)
@@ -22,6 +35,8 @@ const DayView = ({ currentDate, events = [], validRange, onEventClick, onDateCha
   };
 
   const dayEvents = getEventsForDay(currentDate);
+  const packed = packDayEventLanes(dayEvents, DAY_MAX_EVENT_LANES);
+  const placementById = new Map(packed.placements.map((placement) => [placement.id, placement]));
   const [miniCalendarMonth, setMiniCalendarMonth] = useState(currentDate);
 
   // Sync mini calendar month when currentDate changes
@@ -199,6 +214,9 @@ const DayView = ({ currentDate, events = [], validRange, onEventClick, onDateCha
 
               {/* Events */}
               {dayEvents.map((event) => {
+                const placement = placementById.get(String(event.id));
+                if (!placement) return null;
+
                 const eventTop = getEventTop(event.start, currentDate);
                 const eventHeight = getEventHeight(event.start, event.end, currentDate);
                 const isSpanning = isEventSpanningToNextDay(event.start, event.end, currentDate);
@@ -215,11 +233,29 @@ const DayView = ({ currentDate, events = [], validRange, onEventClick, onDateCha
                     isContinuing={isContinuing}
                     isFullDay={isFullDay}
                     dayDate={currentDate}
+                    horizontalLayout={{
+                      leftPercent: placement.leftPercent,
+                      widthPercent: placement.widthPercent,
+                    }}
                     onEventClick={onEventClick}
                     onContextMenu={onEventContextMenu}
                   />
                 );
               })}
+              {onDensityOverflow &&
+                packed.overflows.map((overflow, overflowIndex) => {
+                  const groupTop = getEventTop(overflow.start, currentDate);
+                  const groupHeight = getEventHeight(overflow.start, overflow.end, currentDate);
+                  return (
+                    <DensityOverflowControl
+                      key={`overflow-${overflowIndex}`}
+                      count={overflow.undrawnCount}
+                      date={currentDate}
+                      top={Math.max(groupTop, groupTop + groupHeight - 22)}
+                      onActivate={onDensityOverflow}
+                    />
+                  );
+                })}
             </div>
           </div>
         </div>

--- a/src/components/calendar/DensityOverflowControl.tsx
+++ b/src/components/calendar/DensityOverflowControl.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/utils";
+import { useTranslation } from "react-i18next";
+
+interface DensityOverflowControlProps {
+  count: number;
+  date: Date;
+  top: number;
+  onActivate: (date: Date) => void;
+}
+
+const DensityOverflowControl = ({ count, date, top, onActivate }: DensityOverflowControlProps) => {
+  const { t } = useTranslation("calendar");
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "absolute z-30 max-w-[calc(100%-0.5rem)] truncate rounded border px-1.5 py-0.5 text-[10px] font-medium shadow-sm",
+        "border-gray-300 bg-white text-gray-700 hover:bg-gray-50",
+        "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700",
+      )}
+      style={{ top: `${top}px`, left: "4px" }}
+      onClick={(event) => {
+        event.stopPropagation();
+        onActivate(date);
+      }}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      aria-label={t("densityOverflowAria", { count })}
+    >
+      {t("densityOverflow", { count })}
+    </button>
+  );
+};
+
+export default DensityOverflowControl;

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -1,6 +1,7 @@
-import { Tooltip } from "@efcnewlife/newlife-ui";
 import { cn } from "@/utils";
+import { Tooltip } from "@efcnewlife/newlife-ui";
 import { useTranslation } from "react-i18next";
+import { formatEventTimeClock, formatEventTimeRange } from "./formatEventTime";
 import { CalendarEvent, EventHorizontalLayout } from "./types";
 
 const MAX_VISIBLE_TAGS = 2;
@@ -26,8 +27,8 @@ const getDefaultColorClasses = (): EventColorClasses => {
     bg: "bg-brand-50",
     border: "border-brand-200",
     hoverBg: "hover:bg-brand-100",
-    text: "text-brand-500",
-    timeText: "text-brand-400",
+    text: "text-gray-900",
+    timeText: "text-gray-900",
   };
 };
 
@@ -47,16 +48,7 @@ export interface EventBlockProps {
 /**
  * Event block component for rendering calendar events
  */
-const EventBlock = ({
-  event,
-  top,
-  height,
-  isSpanning,
-  isContinuing,
-  horizontalLayout,
-  onEventClick,
-  onContextMenu,
-}: EventBlockProps) => {
+const EventBlock = ({ event, top, height, isSpanning, isContinuing, horizontalLayout, onEventClick, onContextMenu }: EventBlockProps) => {
   const { i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
   const eventStart = new Date(event.start);
@@ -64,6 +56,8 @@ const EventBlock = ({
   const tags = event.tags?.filter(Boolean) || [];
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS);
   const overflowTags = tags.slice(MAX_VISIBLE_TAGS);
+  const timeRangeLabel = formatEventTimeRange(eventStart, eventEnd, locale);
+  const timeLabel = height > 48 ? timeRangeLabel : formatEventTimeClock(eventStart, locale);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -72,15 +66,6 @@ const EventBlock = ({
       onContextMenu(event, e);
     }
   };
-
-  // Always display original event times
-  const timeOptions: Intl.DateTimeFormatOptions = {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: locale.startsWith("en"),
-  };
-  const startTimeString = eventStart.toLocaleTimeString(locale, timeOptions);
-  const endTimeString = eventEnd.toLocaleTimeString(locale, timeOptions);
 
   // Get default classes based on preset color name (if any)
   const defaultClasses = getDefaultColorClasses();
@@ -114,20 +99,9 @@ const EventBlock = ({
     } else if (isSpanning) {
       return "rounded-t-md border-x border-t";
     } else if (isContinuing) {
-      return "rounded-b-md pt-3 border-x border-b";
+      return "rounded-b-md border-x border-b";
     }
     return "rounded-md border";
-  };
-
-  const getPaddingClasses = (): string => {
-    if (isSpanning && isContinuing) {
-      return "px-1.5";
-    } else if (isSpanning) {
-      return "pt-2 px-1.5";
-    } else if (isContinuing) {
-      return "px-1.5 pb-1.5";
-    }
-    return "px-1.5 py-1.5";
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -137,67 +111,75 @@ const EventBlock = ({
     }
   };
 
+  const tooltipContent = (
+    <div className="max-w-xs space-y-0.5 text-start leading-tight">
+      <div className="font-semibold">{event.title}</div>
+      <div>{timeRangeLabel}</div>
+      {tags.length > 0 && <div className="font-normal opacity-90">{tags.join(", ")}</div>}
+    </div>
+  );
+
+  // 1px vertical inset keeps a hairline gap between stacked events without pushing text down.
+  const verticalInsetPx = isSpanning && isContinuing ? 0 : 1;
+  const layoutTop = top + (isContinuing ? 0 : verticalInsetPx);
+  const layoutHeight = Math.max(height - (isSpanning ? verticalInsetPx : verticalInsetPx * 2), 1);
+
   return (
     <div
-      className={cn(
-        "absolute",
-        horizontalLayout ? "z-10 box-border min-w-0 overflow-hidden" : "w-full",
-        getPaddingClasses(),
-      )}
+      className={cn("absolute px-1 py-1", horizontalLayout ? "box-border min-w-0 overflow-hidden" : "w-full")}
       style={{
-        top: `${top}px`,
-        height: `${height}px`,
-        left: horizontalLayout ? `${horizontalLayout.leftPercent}%` : 0,
-        width: horizontalLayout ? `${horizontalLayout.widthPercent}%` : "100%",
+        top: `${layoutTop}px`,
+        height: `${layoutHeight}px`,
+        ...(horizontalLayout
+          ? {
+              left: `${horizontalLayout.leftPercent}%`,
+              width: `${horizontalLayout.widthPercent}%`,
+              zIndex: 10 + (horizontalLayout.laneIndex ?? 0),
+            }
+          : {}),
       }}
     >
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={() => onEventClick?.(event)}
-        onKeyDown={handleKeyDown}
-        onContextMenu={handleContextMenu}
-        className={cn(
-          "flex h-full w-full flex-1 cursor-pointer flex-col gap-0.5",
-          getEventClasses(),
-          "px-1 py-0.5",
-          colorClasses.bg,
-          colorClasses.border,
-          colorClasses.hoverBg,
-          "relative",
-        )}
-        style={inlineStyles}
-      >
-        <div className="flex w-full flex-col items-start relative">
-          <div className="flex w-full flex-col items-start gap-0.5">
+      <Tooltip content={tooltipContent} placement="top" className="!flex h-full w-full" contentClassName="pointer-events-none">
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => onEventClick?.(event)}
+          onKeyDown={handleKeyDown}
+          onContextMenu={handleContextMenu}
+          className={cn(
+            "relative flex h-full w-full min-w-0 cursor-pointer flex-col justify-start gap-0 overflow-hidden px-1 py-1 leading-none",
+            getEventClasses(),
+            colorClasses.bg,
+            colorClasses.border,
+            colorClasses.hoverBg,
+          )}
+          style={inlineStyles}
+        >
+          <div
+            className={cn("truncate text-start text-xs font-semibold leading-none", colorClasses.text)}
+            style={inlineStyles.color ? { color: inlineStyles.color } : undefined}
+          >
+            {event.title}
+          </div>
+          <div
+            className={cn("truncate text-xs leading-none", colorClasses.timeText)}
+            style={inlineStyles.color ? { color: inlineStyles.color } : undefined}
+          >
+            {timeLabel}
+          </div>
+          {visibleTags.length > 0 && height > 48 && (
             <div
-              className={cn("text-xs font-semibold text-start", colorClasses.text)}
+              className={cn("flex max-w-full items-center gap-0.5 text-[10px] leading-none", colorClasses.timeText)}
               style={inlineStyles.color ? { color: inlineStyles.color } : undefined}
             >
-              {event.title}
+              <span className="truncate">{visibleTags.join(", ")}</span>
+              {overflowTags.length > 0 && (
+                <span className={cn("shrink-0 rounded px-0.5 font-semibold", colorClasses.text)}>+{overflowTags.length}</span>
+              )}
             </div>
-            {visibleTags.length > 0 && height > 28 && (
-              <div
-                className={cn("flex max-w-full items-center gap-0.5 text-[10px] leading-tight", colorClasses.timeText)}
-                style={inlineStyles.color ? { color: inlineStyles.color } : undefined}
-              >
-                <span className="truncate">{visibleTags.join(", ")}</span>
-                {overflowTags.length > 0 && (
-                  <Tooltip content={overflowTags.join(", ")} placement="top">
-                    <span className={cn("shrink-0 rounded px-0.5 font-semibold", colorClasses.text)}>
-                      +{overflowTags.length}
-                    </span>
-                  </Tooltip>
-                )}
-              </div>
-            )}
-            <div className={cn("text-xs", colorClasses.timeText)} style={inlineStyles.color ? { color: inlineStyles.color } : undefined}>
-              {startTimeString}
-              {height > 48 && ` – ${endTimeString}`}
-            </div>
-          </div>
+          )}
         </div>
-      </div>
+      </Tooltip>
     </div>
   );
 };

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@efcnewlife/newlife-ui";
 import { cn } from "@/utils";
 import { useTranslation } from "react-i18next";
-import { CalendarEvent } from "./types";
+import { CalendarEvent, EventHorizontalLayout } from "./types";
 
 const MAX_VISIBLE_TAGS = 2;
 
@@ -39,6 +39,7 @@ export interface EventBlockProps {
   isContinuing?: boolean; // Event continues from previous day
   isFullDay?: boolean; // Event is fully within this day
   dayDate?: Date; // The date this event block represents
+  horizontalLayout?: EventHorizontalLayout;
   onEventClick?: (event: CalendarEvent) => void;
   onContextMenu?: (event: CalendarEvent, mouseEvent: React.MouseEvent) => void;
 }
@@ -46,7 +47,16 @@ export interface EventBlockProps {
 /**
  * Event block component for rendering calendar events
  */
-const EventBlock = ({ event, top, height, isSpanning, isContinuing, onEventClick, onContextMenu }: EventBlockProps) => {
+const EventBlock = ({
+  event,
+  top,
+  height,
+  isSpanning,
+  isContinuing,
+  horizontalLayout,
+  onEventClick,
+  onContextMenu,
+}: EventBlockProps) => {
   const { i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
   const eventStart = new Date(event.start);
@@ -129,10 +139,16 @@ const EventBlock = ({ event, top, height, isSpanning, isContinuing, onEventClick
 
   return (
     <div
-      className={`absolute w-full ${getPaddingClasses()}`}
+      className={cn(
+        "absolute",
+        horizontalLayout ? "z-10 box-border min-w-0 overflow-hidden" : "w-full",
+        getPaddingClasses(),
+      )}
       style={{
         top: `${top}px`,
         height: `${height}px`,
+        left: horizontalLayout ? `${horizontalLayout.leftPercent}%` : 0,
+        width: horizontalLayout ? `${horizontalLayout.widthPercent}%` : "100%",
       }}
     >
       <div

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,8 +1,12 @@
 import { MdAdd } from "react-icons/md";
 import { useTranslation } from "react-i18next";
+import DensityOverflowControl from "./DensityOverflowControl";
 import EventBlock from "./EventBlock";
+import { packDayEventLanes } from "./packDayEventLanes";
 import { CalendarViewProps } from "./types";
 import { filterEventsByDateRange, formatWeekday, getWeekDates, isDateInRange } from "./utils";
+
+const WEEK_MAX_EVENT_LANES = 4;
 
 const WeekView = ({
   currentDate,
@@ -12,6 +16,7 @@ const WeekView = ({
   onDateChange,
   onAddEvent,
   onEventContextMenu,
+  onDensityOverflow,
 }: CalendarViewProps) => {
   const { t, i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
@@ -173,6 +178,8 @@ const WeekView = ({
         <div className="grid flex-1 grid-cols-7">
           {weekDates.map((date, dayIndex) => {
             const dayEvents = getEventsForDay(date);
+            const packed = packDayEventLanes(dayEvents, WEEK_MAX_EVENT_LANES);
+            const placementById = new Map(packed.placements.map((placement) => [placement.id, placement]));
             const isLastColumn = dayIndex === 6;
             return (
               <div key={dayIndex} className="flex flex-col border-gray-300 dark:border-white/10">
@@ -228,6 +235,9 @@ const WeekView = ({
 
                   {/* Events */}
                   {dayEvents.map((event) => {
+                    const placement = placementById.get(String(event.id));
+                    if (!placement) return null;
+
                     const eventTop = getEventTop(event.start, date);
                     const eventHeight = getEventHeight(event.start, event.end, date);
                     const isSpanning = isEventSpanningToNextDay(event.start, event.end, date);
@@ -244,11 +254,29 @@ const WeekView = ({
                         isContinuing={isContinuing}
                         isFullDay={isFullDay}
                         dayDate={date}
+                        horizontalLayout={{
+                          leftPercent: placement.leftPercent,
+                          widthPercent: placement.widthPercent,
+                        }}
                         onEventClick={onEventClick}
                         onContextMenu={onEventContextMenu}
                       />
                     );
                   })}
+                  {onDensityOverflow &&
+                    packed.overflows.map((overflow, overflowIndex) => {
+                      const groupTop = getEventTop(overflow.start, date);
+                      const groupHeight = getEventHeight(overflow.start, overflow.end, date);
+                      return (
+                        <DensityOverflowControl
+                          key={`overflow-${dayIndex}-${overflowIndex}`}
+                          count={overflow.undrawnCount}
+                          date={date}
+                          top={Math.max(groupTop, groupTop + groupHeight - 22)}
+                          onActivate={onDensityOverflow}
+                        />
+                      );
+                    })}
                 </div>
               </div>
             );

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,5 +1,5 @@
-import { MdAdd } from "react-icons/md";
 import { useTranslation } from "react-i18next";
+import { MdAdd } from "react-icons/md";
 import DensityOverflowControl from "./DensityOverflowControl";
 import EventBlock from "./EventBlock";
 import { packDayEventLanes } from "./packDayEventLanes";
@@ -151,8 +151,8 @@ const WeekView = ({
                   isToday
                     ? "w-6 rounded-full bg-indigo-600 text-white dark:bg-indigo-500"
                     : isSelected
-                    ? "w-6 rounded-full bg-gray-900 text-white dark:bg-white dark:text-gray-900"
-                    : "text-gray-900 dark:text-white"
+                      ? "w-6 rounded-full bg-gray-900 text-white dark:bg-white dark:text-gray-900"
+                      : "text-gray-900 dark:text-white"
                 }`}
               >
                 {date.getDate()}
@@ -257,6 +257,7 @@ const WeekView = ({
                         horizontalLayout={{
                           leftPercent: placement.leftPercent,
                           widthPercent: placement.widthPercent,
+                          laneIndex: placement.laneIndex,
                         }}
                         onEventClick={onEventClick}
                         onContextMenu={onEventContextMenu}

--- a/src/components/calendar/formatEventTime.test.ts
+++ b/src/components/calendar/formatEventTime.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatEventTimeClock, formatEventTimeRange } from "./formatEventTime";
+
+const at = (hour: number, minute = 0): Date => new Date(2026, 7, 13, hour, minute, 0, 0);
+
+describe("formatEventTimeClock", () => {
+  it("formats English 12h with lowercase period and omits :00", () => {
+    expect(formatEventTimeClock(at(13, 0), "en")).toBe("1pm");
+    expect(formatEventTimeClock(at(13, 35), "en")).toBe("1:35pm");
+    expect(formatEventTimeClock(at(0, 0), "en")).toBe("12am");
+    expect(formatEventTimeClock(at(12, 0), "en")).toBe("12pm");
+  });
+
+  it("formats non-English as 24h without period", () => {
+    expect(formatEventTimeClock(at(13, 0), "zh-TW")).toBe("13");
+    expect(formatEventTimeClock(at(13, 35), "zh-TW")).toBe("13:35");
+  });
+});
+
+describe("formatEventTimeRange", () => {
+  it("keeps am/pm only on the end when both times share a period", () => {
+    expect(formatEventTimeRange(at(13, 35), at(16, 35), "en")).toBe("1:35 – 4:35pm");
+  });
+
+  it("shows both periods when the range crosses noon or midnight", () => {
+    expect(formatEventTimeRange(at(11, 30), at(13, 0), "en")).toBe("11:30am – 1pm");
+    expect(formatEventTimeRange(at(23, 30), at(1, 0), "en")).toBe("11:30pm – 1am");
+  });
+
+  it("omits :00 minutes on either side", () => {
+    expect(formatEventTimeRange(at(11, 0), at(13, 0), "en")).toBe("11am – 1pm");
+  });
+
+  it("formats non-English ranges in 24h with an en dash", () => {
+    expect(formatEventTimeRange(at(13, 35), at(16, 35), "zh-TW")).toBe("13:35 – 16:35");
+    expect(formatEventTimeRange(at(11, 30), at(13, 0), "zh-CN")).toBe("11:30 – 13");
+  });
+});

--- a/src/components/calendar/formatEventTime.ts
+++ b/src/components/calendar/formatEventTime.ts
@@ -1,0 +1,48 @@
+const padMinute = (minute: number): string => minute.toString().padStart(2, "0");
+
+const periodOf = (date: Date): "am" | "pm" => (date.getHours() < 12 ? "am" : "pm");
+
+const format12hClock = (date: Date, includePeriod: boolean): string => {
+  const hour24 = date.getHours();
+  const minute = date.getMinutes();
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const clock = minute === 0 ? `${hour12}` : `${hour12}:${padMinute(minute)}`;
+  if (!includePeriod) {
+    return clock;
+  }
+  return `${clock}${periodOf(date)}`;
+};
+
+const format24hClock = (date: Date): string => {
+  const hour = date.getHours();
+  const minute = date.getMinutes();
+  return minute === 0 ? `${hour}` : `${hour}:${padMinute(minute)}`;
+};
+
+/**
+ * Formats a single clock time for Calendar event blocks.
+ * English uses Google-style 12h (lowercase am/pm, omit :00).
+ * Other locales use 24h without a period suffix.
+ */
+export const formatEventTimeClock = (date: Date, locale: string): string => {
+  if (locale.startsWith("en")) {
+    return format12hClock(date, true);
+  }
+  return format24hClock(date);
+};
+
+/**
+ * Formats a start-end range like Google Calendar week/day blocks.
+ * English same period: "1:35 – 4:35pm"; cross period: "11:30am – 1pm".
+ * Other locales: "13:35 – 16:35" (omit :00).
+ */
+export const formatEventTimeRange = (start: Date, end: Date, locale: string): string => {
+  if (!locale.startsWith("en")) {
+    return `${format24hClock(start)} – ${format24hClock(end)}`;
+  }
+
+  const samePeriod = periodOf(start) === periodOf(end);
+  const startText = format12hClock(start, !samePeriod);
+  const endText = format12hClock(end, true);
+  return `${startText} – ${endText}`;
+};

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -2,6 +2,14 @@ export { default as Calendar } from "./Calendar";
 export { default as CalendarToolBar } from "./CalendarToolbar";
 export { default as DayView } from "./DayView";
 export { default as MonthView } from "./MonthView";
-export type { CalendarDay, CalendarEvent, CalendarMonth, CalendarProps, CalendarView, CalendarViewProps } from "./types";
+export type {
+  CalendarDay,
+  CalendarEvent,
+  CalendarMonth,
+  CalendarProps,
+  CalendarView,
+  CalendarViewProps,
+  EventHorizontalLayout,
+} from "./types";
 export * from "./utils";
 export { default as WeekView } from "./WeekView";

--- a/src/components/calendar/packDayEventLanes.test.ts
+++ b/src/components/calendar/packDayEventLanes.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { packDayEventLanes, type PackableEvent } from "./packDayEventLanes";
+
+const at = (hour: number, minute = 0): Date => new Date(2026, 7, 13, hour, minute, 0, 0);
+
+const event = (id: string, startHour: number, endHour: number, startMinute = 0, endMinute = 0): PackableEvent => ({
+  id,
+  start: at(startHour, startMinute),
+  end: at(endHour, endMinute),
+});
+
+const placementById = (events: PackableEvent[], maxLaneCount: number) => {
+  const result = packDayEventLanes(events, maxLaneCount);
+  return {
+    result,
+    byId: Object.fromEntries(result.placements.map((placement) => [placement.id, placement])),
+  };
+};
+
+describe("packDayEventLanes", () => {
+  it("returns no placements or overflow for an empty day", () => {
+    expect(packDayEventLanes([], 4)).toEqual({ placements: [], overflows: [] });
+  });
+
+  it("gives a single event the full day column", () => {
+    const { result, byId } = placementById([event("solo", 14, 16)], 4);
+    expect(result.overflows).toEqual([]);
+    expect(byId.solo).toEqual({
+      id: "solo",
+      laneIndex: 0,
+      leftPercent: 0,
+      widthPercent: 100,
+    });
+  });
+
+  it("splits two overlapping events into equal 50/50 lanes", () => {
+    const { result, byId } = placementById([event("a", 9, 11), event("b", 10, 12)], 4);
+    expect(result.overflows).toEqual([]);
+    expect(result.placements).toHaveLength(2);
+    expect(byId.a).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 50 });
+    expect(byId.b).toMatchObject({ laneIndex: 1, leftPercent: 50, widthPercent: 50 });
+  });
+
+  it("packs a chain of overlaps so C reuses A's lane after A ends", () => {
+    const { result, byId } = placementById(
+      [event("a", 9, 12), event("b", 11, 13), event("c", 12, 14, 30, 0)],
+      4,
+    );
+    expect(result.overflows).toEqual([]);
+    expect(byId.a.laneIndex).toBe(0);
+    expect(byId.b.laneIndex).toBe(1);
+    expect(byId.c.laneIndex).toBe(0);
+    expect(byId.a.widthPercent).toBe(50);
+    expect(byId.b.widthPercent).toBe(50);
+    expect(byId.c.widthPercent).toBe(50);
+  });
+
+  it("treats back-to-back events as non-overlapping full-width blocks", () => {
+    const { result, byId } = placementById([event("a", 9, 10), event("b", 10, 11)], 4);
+    expect(result.overflows).toEqual([]);
+    expect(byId.a).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
+    expect(byId.b).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
+  });
+
+  it("keeps morning and afternoon collision groups on independent widths", () => {
+    const { result, byId } = placementById(
+      [event("morning-a", 9, 11), event("morning-b", 10, 12), event("afternoon", 15, 16)],
+      4,
+    );
+    expect(result.overflows).toEqual([]);
+    expect(byId["morning-a"].widthPercent).toBe(50);
+    expect(byId["morning-b"].widthPercent).toBe(50);
+    expect(byId.afternoon).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
+  });
+
+  it("hides the 5th concurrent event when K is 4 and reports overflow 1", () => {
+    const events = [
+      event("a", 9, 15),
+      event("b", 9, 14),
+      event("c", 9, 13),
+      event("d", 9, 12),
+      event("e", 9, 11),
+    ];
+    const { result, byId } = placementById(events, 4);
+    expect(result.placements).toHaveLength(4);
+    expect(byId.e).toBeUndefined();
+    expect(result.overflows).toHaveLength(1);
+    expect(result.overflows[0].undrawnCount).toBe(1);
+    expect(byId.a.widthPercent).toBe(25);
+    expect(byId.b.widthPercent).toBe(25);
+    expect(byId.c.widthPercent).toBe(25);
+    expect(byId.d.widthPercent).toBe(25);
+  });
+
+  it("hides the 11th concurrent event when K is 10 and reports overflow 1", () => {
+    const events = Array.from({ length: 11 }, (_, index) =>
+      event(String.fromCharCode(97 + index), 9, 20 - index),
+    );
+    const { result } = placementById(events, 10);
+    expect(result.placements).toHaveLength(10);
+    expect(result.placements.every((placement) => placement.widthPercent === 10)).toBe(true);
+    expect(result.overflows).toHaveLength(1);
+    expect(result.overflows[0].undrawnCount).toBe(1);
+    expect(result.placements.find((placement) => placement.id === "k")).toBeUndefined();
+  });
+});

--- a/src/components/calendar/packDayEventLanes.test.ts
+++ b/src/components/calendar/packDayEventLanes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { packDayEventLanes, type PackableEvent } from "./packDayEventLanes";
+import {
+  OVERLAY_INDENT_RATIO,
+  OVERLAY_MIN_WIDTH_RATIO,
+  packDayEventLanes,
+  type EventLanePlacement,
+  type PackableEvent,
+} from "./packDayEventLanes";
 
 const at = (hour: number, minute = 0): Date => new Date(2026, 7, 13, hour, minute, 0, 0);
 
@@ -17,6 +23,13 @@ const placementById = (events: PackableEvent[], maxLaneCount: number) => {
   };
 };
 
+const rightEdge = (placement: EventLanePlacement): number => placement.leftPercent + placement.widthPercent;
+
+const expectedOverlay = (laneIndex: number) => {
+  const leftPercent = Math.min(laneIndex * OVERLAY_INDENT_RATIO, 1 - OVERLAY_MIN_WIDTH_RATIO) * 100;
+  return { leftPercent, widthPercent: 100 - leftPercent };
+};
+
 describe("packDayEventLanes", () => {
   it("returns no placements or overflow for an empty day", () => {
     expect(packDayEventLanes([], 4)).toEqual({ placements: [], overflows: [] });
@@ -25,7 +38,7 @@ describe("packDayEventLanes", () => {
   it("gives a single event the full day column", () => {
     const { result, byId } = placementById([event("solo", 14, 16)], 4);
     expect(result.overflows).toEqual([]);
-    expect(byId.solo).toEqual({
+    expect(byId.solo).toMatchObject({
       id: "solo",
       laneIndex: 0,
       leftPercent: 0,
@@ -33,26 +46,60 @@ describe("packDayEventLanes", () => {
     });
   });
 
-  it("splits two overlapping events into equal 50/50 lanes", () => {
-    const { result, byId } = placementById([event("a", 9, 11), event("b", 10, 12)], 4);
+  it("overlays a later event with a slight indent on a full-width earlier event", () => {
+    const { result, byId } = placementById([event("a", 9, 12), event("b", 10, 11)], 4);
     expect(result.overflows).toEqual([]);
     expect(result.placements).toHaveLength(2);
-    expect(byId.a).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 50 });
-    expect(byId.b).toMatchObject({ laneIndex: 1, leftPercent: 50, widthPercent: 50 });
+    expect(byId.a).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
+    expect(byId.b).toMatchObject({ laneIndex: 1, ...expectedOverlay(1) });
+    expect(rightEdge(byId.b)).toBeCloseTo(100);
   });
 
-  it("packs a chain of overlaps so C reuses A's lane after A ends", () => {
-    const { result, byId } = placementById(
-      [event("a", 9, 12), event("b", 11, 13), event("c", 12, 14, 30, 0)],
-      4,
-    );
+  it("keeps a long event full width and stacks back-to-back shorts in the same overlay column", () => {
+    const { result, byId } = placementById([event("long", 13, 16, 35, 35), event("mid", 15, 16, 0, 30), event("tail", 16, 18, 30, 0)], 4);
+    expect(result.overflows).toEqual([]);
+    expect(byId.long).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
+    expect(byId.mid.laneIndex).toBe(1);
+    expect(byId.tail.laneIndex).toBe(1);
+    expect(byId.mid).toMatchObject(expectedOverlay(1));
+    expect(byId.tail).toMatchObject(expectedOverlay(1));
+    expect(rightEdge(byId.mid)).toBeCloseTo(100);
+    expect(rightEdge(byId.tail)).toBeCloseTo(100);
+  });
+
+  it("stacks dense concurrent events as a right-aligned card stack with full-width base", () => {
+    const events = [
+      event("base", 19, 22),
+      event("t1", 20, 21, 30, 0),
+      event("t2", 20, 21, 30, 0),
+      event("t3", 20, 21, 30, 0),
+      event("t4", 20, 21, 30, 0),
+      event("t5", 20, 21, 30, 0),
+      event("later", 21, 22),
+    ];
+    const { result, byId } = placementById(events, 10);
+    expect(result.overflows).toEqual([]);
+    expect(byId.base).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
+    expect(byId.t1.laneIndex).toBe(1);
+    expect(byId.t5.laneIndex).toBe(5);
+    expect(byId.later.laneIndex).toBe(1);
+    expect(byId.t1.leftPercent).toBeLessThan(byId.t5.leftPercent);
+    expect(byId.t5.widthPercent).toBeLessThan(byId.t1.widthPercent);
+    expect(rightEdge(byId.t1)).toBeCloseTo(100);
+    expect(rightEdge(byId.t5)).toBeCloseTo(100);
+    expect(rightEdge(byId.later)).toBeCloseTo(100);
+    expect(byId.later).toMatchObject(expectedOverlay(1));
+  });
+
+  it("packs a chain of partial overlaps so C reuses A's lane after A ends", () => {
+    const { result, byId } = placementById([event("a", 9, 12), event("b", 11, 13), event("c", 12, 14, 30, 0)], 4);
     expect(result.overflows).toEqual([]);
     expect(byId.a.laneIndex).toBe(0);
     expect(byId.b.laneIndex).toBe(1);
     expect(byId.c.laneIndex).toBe(0);
-    expect(byId.a.widthPercent).toBe(50);
-    expect(byId.b.widthPercent).toBe(50);
-    expect(byId.c.widthPercent).toBe(50);
+    expect(byId.a).toMatchObject({ leftPercent: 0, widthPercent: 100 });
+    expect(byId.b).toMatchObject(expectedOverlay(1));
+    expect(byId.c).toMatchObject({ leftPercent: 0, widthPercent: 100 });
   });
 
   it("treats back-to-back events as non-overlapping full-width blocks", () => {
@@ -63,44 +110,36 @@ describe("packDayEventLanes", () => {
   });
 
   it("keeps morning and afternoon collision groups on independent widths", () => {
-    const { result, byId } = placementById(
-      [event("morning-a", 9, 11), event("morning-b", 10, 12), event("afternoon", 15, 16)],
-      4,
-    );
+    const { result, byId } = placementById([event("morning-a", 9, 11), event("morning-b", 10, 12), event("afternoon", 15, 16)], 4);
     expect(result.overflows).toEqual([]);
-    expect(byId["morning-a"].widthPercent).toBe(50);
-    expect(byId["morning-b"].widthPercent).toBe(50);
+    expect(byId["morning-a"]).toMatchObject({ leftPercent: 0, widthPercent: 100 });
+    expect(byId["morning-b"]).toMatchObject(expectedOverlay(1));
     expect(byId.afternoon).toMatchObject({ laneIndex: 0, leftPercent: 0, widthPercent: 100 });
   });
 
   it("hides the 5th concurrent event when K is 4 and reports overflow 1", () => {
-    const events = [
-      event("a", 9, 15),
-      event("b", 9, 14),
-      event("c", 9, 13),
-      event("d", 9, 12),
-      event("e", 9, 11),
-    ];
+    const events = [event("a", 9, 11), event("b", 9, 11), event("c", 9, 11), event("d", 9, 11), event("e", 9, 11)];
     const { result, byId } = placementById(events, 4);
     expect(result.placements).toHaveLength(4);
     expect(byId.e).toBeUndefined();
     expect(result.overflows).toHaveLength(1);
     expect(result.overflows[0].undrawnCount).toBe(1);
-    expect(byId.a.widthPercent).toBe(25);
-    expect(byId.b.widthPercent).toBe(25);
-    expect(byId.c.widthPercent).toBe(25);
-    expect(byId.d.widthPercent).toBe(25);
+    expect(byId.a).toMatchObject(expectedOverlay(0));
+    expect(byId.b).toMatchObject(expectedOverlay(1));
+    expect(byId.c).toMatchObject(expectedOverlay(2));
+    expect(byId.d).toMatchObject(expectedOverlay(3));
   });
 
   it("hides the 11th concurrent event when K is 10 and reports overflow 1", () => {
-    const events = Array.from({ length: 11 }, (_, index) =>
-      event(String.fromCharCode(97 + index), 9, 20 - index),
-    );
+    const events = Array.from({ length: 11 }, (_, index) => event(String.fromCharCode(97 + index), 9, 11));
     const { result } = placementById(events, 10);
     expect(result.placements).toHaveLength(10);
-    expect(result.placements.every((placement) => placement.widthPercent === 10)).toBe(true);
     expect(result.overflows).toHaveLength(1);
     expect(result.overflows[0].undrawnCount).toBe(1);
     expect(result.placements.find((placement) => placement.id === "k")).toBeUndefined();
+    result.placements.forEach((placement) => {
+      expect(placement).toMatchObject(expectedOverlay(placement.laneIndex));
+      expect(rightEdge(placement)).toBeCloseTo(100);
+    });
   });
 });

--- a/src/components/calendar/packDayEventLanes.ts
+++ b/src/components/calendar/packDayEventLanes.ts
@@ -30,6 +30,12 @@ interface NormalizedEvent {
   end: Date;
 }
 
+/** Fraction of the day column each later lane indents from the left (card stack). */
+export const OVERLAY_INDENT_RATIO = 0.12;
+
+/** Minimum width fraction so high lane indices stay clickable. */
+export const OVERLAY_MIN_WIDTH_RATIO = 0.2;
+
 const toDate = (value: string | Date): Date => (value instanceof Date ? value : new Date(value));
 
 const normalizeEvent = (event: PackableEvent): NormalizedEvent => {
@@ -93,10 +99,7 @@ const findCollisionGroups = (events: NormalizedEvent[]): NormalizedEvent[][] => 
   });
 };
 
-const packGroup = (
-  group: NormalizedEvent[],
-  maxLaneCount: number,
-): { placements: EventLanePlacement[]; overflow: CollisionGroupOverflow | null } => {
+const assignColumns = (group: NormalizedEvent[]): Map<string, number> => {
   const sorted = [...group].sort((left, right) => {
     const byStart = left.startMs - right.startMs;
     if (byStart !== 0) {
@@ -119,11 +122,33 @@ const packGroup = (
     columnById.set(event.id, column);
   });
 
-  const columnsNeeded = Math.max(1, columnEnds.length);
-  const visibleLaneCount = Math.min(columnsNeeded, maxLaneCount);
-  const widthPercent = 100 / visibleLaneCount;
+  return columnById;
+};
+
+const overlayPlacement = (laneIndex: number): { leftPercent: number; widthPercent: number } => {
+  const leftRatio = Math.min(laneIndex * OVERLAY_INDENT_RATIO, 1 - OVERLAY_MIN_WIDTH_RATIO);
+  const leftPercent = leftRatio * 100;
+  return {
+    leftPercent,
+    widthPercent: 100 - leftPercent,
+  };
+};
+
+const packGroup = (
+  group: NormalizedEvent[],
+  maxLaneCount: number,
+): { placements: EventLanePlacement[]; overflow: CollisionGroupOverflow | null } => {
+  const columnById = assignColumns(group);
   const placements: EventLanePlacement[] = [];
   let undrawnCount = 0;
+
+  const sorted = [...group].sort((left, right) => {
+    const byStart = left.startMs - right.startMs;
+    if (byStart !== 0) {
+      return byStart;
+    }
+    return right.endMs - left.endMs;
+  });
 
   sorted.forEach((event) => {
     const laneIndex = columnById.get(event.id) ?? 0;
@@ -131,10 +156,11 @@ const packGroup = (
       undrawnCount += 1;
       return;
     }
+    const { leftPercent, widthPercent } = overlayPlacement(laneIndex);
     placements.push({
       id: event.id,
       laneIndex,
-      leftPercent: (laneIndex / visibleLaneCount) * 100,
+      leftPercent,
       widthPercent,
     });
   });
@@ -158,11 +184,11 @@ export const packDayEventLanes = (events: PackableEvent[], maxLaneCount: number)
     return { placements: [], overflows: [] };
   }
 
-  const groups = findCollisionGroups(events.map(normalizeEvent));
+  const normalized = events.map(normalizeEvent);
   const placements: EventLanePlacement[] = [];
   const overflows: CollisionGroupOverflow[] = [];
 
-  groups.forEach((group) => {
+  findCollisionGroups(normalized).forEach((group) => {
     const packed = packGroup(group, maxLaneCount);
     placements.push(...packed.placements);
     if (packed.overflow) {

--- a/src/components/calendar/packDayEventLanes.ts
+++ b/src/components/calendar/packDayEventLanes.ts
@@ -1,0 +1,174 @@
+export interface PackableEvent {
+  id: string | number;
+  start: string | Date;
+  end: string | Date;
+}
+
+export interface EventLanePlacement {
+  id: string;
+  laneIndex: number;
+  leftPercent: number;
+  widthPercent: number;
+}
+
+export interface CollisionGroupOverflow {
+  undrawnCount: number;
+  start: Date;
+  end: Date;
+}
+
+export interface PackDayEventLanesResult {
+  placements: EventLanePlacement[];
+  overflows: CollisionGroupOverflow[];
+}
+
+interface NormalizedEvent {
+  id: string;
+  startMs: number;
+  endMs: number;
+  start: Date;
+  end: Date;
+}
+
+const toDate = (value: string | Date): Date => (value instanceof Date ? value : new Date(value));
+
+const normalizeEvent = (event: PackableEvent): NormalizedEvent => {
+  const start = toDate(event.start);
+  const end = toDate(event.end);
+  return {
+    id: String(event.id),
+    startMs: start.getTime(),
+    endMs: end.getTime(),
+    start,
+    end,
+  };
+};
+
+const intervalsOverlap = (left: NormalizedEvent, right: NormalizedEvent): boolean =>
+  left.startMs < right.endMs && right.startMs < left.endMs;
+
+const findCollisionGroups = (events: NormalizedEvent[]): NormalizedEvent[][] => {
+  const parent = events.map((_, index) => index);
+
+  const find = (index: number): number => {
+    let current = index;
+    while (parent[current] !== current) {
+      parent[current] = parent[parent[current]];
+      current = parent[current];
+    }
+    return current;
+  };
+
+  const union = (left: number, right: number) => {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) {
+      parent[leftRoot] = rightRoot;
+    }
+  };
+
+  for (let i = 0; i < events.length; i += 1) {
+    for (let j = i + 1; j < events.length; j += 1) {
+      if (intervalsOverlap(events[i], events[j])) {
+        union(i, j);
+      }
+    }
+  }
+
+  const grouped = new Map<number, NormalizedEvent[]>();
+  events.forEach((event, index) => {
+    const root = find(index);
+    const group = grouped.get(root);
+    if (group) {
+      group.push(event);
+    } else {
+      grouped.set(root, [event]);
+    }
+  });
+
+  return [...grouped.values()].sort((left, right) => {
+    const leftStart = Math.min(...left.map((event) => event.startMs));
+    const rightStart = Math.min(...right.map((event) => event.startMs));
+    return leftStart - rightStart;
+  });
+};
+
+const packGroup = (
+  group: NormalizedEvent[],
+  maxLaneCount: number,
+): { placements: EventLanePlacement[]; overflow: CollisionGroupOverflow | null } => {
+  const sorted = [...group].sort((left, right) => {
+    const byStart = left.startMs - right.startMs;
+    if (byStart !== 0) {
+      return byStart;
+    }
+    return right.endMs - left.endMs;
+  });
+
+  const columnEnds: number[] = [];
+  const columnById = new Map<string, number>();
+
+  sorted.forEach((event) => {
+    let column = columnEnds.findIndex((lastEndMs) => lastEndMs <= event.startMs);
+    if (column === -1) {
+      column = columnEnds.length;
+      columnEnds.push(event.endMs);
+    } else {
+      columnEnds[column] = Math.max(columnEnds[column], event.endMs);
+    }
+    columnById.set(event.id, column);
+  });
+
+  const columnsNeeded = Math.max(1, columnEnds.length);
+  const visibleLaneCount = Math.min(columnsNeeded, maxLaneCount);
+  const widthPercent = 100 / visibleLaneCount;
+  const placements: EventLanePlacement[] = [];
+  let undrawnCount = 0;
+
+  sorted.forEach((event) => {
+    const laneIndex = columnById.get(event.id) ?? 0;
+    if (laneIndex >= maxLaneCount) {
+      undrawnCount += 1;
+      return;
+    }
+    placements.push({
+      id: event.id,
+      laneIndex,
+      leftPercent: (laneIndex / visibleLaneCount) * 100,
+      widthPercent,
+    });
+  });
+
+  if (undrawnCount === 0) {
+    return { placements, overflow: null };
+  }
+
+  return {
+    placements,
+    overflow: {
+      undrawnCount,
+      start: new Date(Math.min(...group.map((event) => event.startMs))),
+      end: new Date(Math.max(...group.map((event) => event.endMs))),
+    },
+  };
+};
+
+export const packDayEventLanes = (events: PackableEvent[], maxLaneCount: number): PackDayEventLanesResult => {
+  if (events.length === 0) {
+    return { placements: [], overflows: [] };
+  }
+
+  const groups = findCollisionGroups(events.map(normalizeEvent));
+  const placements: EventLanePlacement[] = [];
+  const overflows: CollisionGroupOverflow[] = [];
+
+  groups.forEach((group) => {
+    const packed = packGroup(group, maxLaneCount);
+    placements.push(...packed.placements);
+    if (packed.overflow) {
+      overflows.push(packed.overflow);
+    }
+  });
+
+  return { placements, overflows };
+};

--- a/src/components/calendar/types.ts
+++ b/src/components/calendar/types.ts
@@ -16,6 +16,8 @@ export interface CalendarEvent {
 export interface EventHorizontalLayout {
   leftPercent: number;
   widthPercent: number;
+  /** Greedy column index; higher draws on top in the card stack. */
+  laneIndex?: number;
 }
 
 export interface CalendarDay {

--- a/src/components/calendar/types.ts
+++ b/src/components/calendar/types.ts
@@ -12,6 +12,12 @@ export interface CalendarEvent {
   item?: unknown;
 }
 
+/** Horizontal placement as percent of the day column. Omitted layout stays full width. */
+export interface EventHorizontalLayout {
+  leftPercent: number;
+  widthPercent: number;
+}
+
 export interface CalendarDay {
   date: string;
   isCurrentMonth?: boolean;
@@ -41,6 +47,7 @@ export interface CalendarProps {
   onEventClick?: (event: CalendarEvent) => void;
   onEventContextMenu?: (event: CalendarEvent, mouseEvent: React.MouseEvent) => void;
   onAddEvent?: (date?: Date, startTime?: string, endTime?: string) => void;
+  onDensityOverflow?: (date: Date) => void;
   showNavigationButtons?:
     | boolean
     | {
@@ -58,4 +65,5 @@ export interface CalendarViewProps {
   onEventClick?: (event: CalendarEvent) => void;
   onEventContextMenu?: (event: CalendarEvent, mouseEvent: React.MouseEvent) => void;
   onAddEvent?: (date?: Date, startTime?: string, endTime?: string) => void;
+  onDensityOverflow?: (date: Date) => void;
 }

--- a/src/i18n/locales/en/calendar.json
+++ b/src/i18n/locales/en/calendar.json
@@ -7,6 +7,8 @@
   "today": "Today",
   "weekOfMonth": "Week {{week}}",
   "addBooking": "Add booking",
+  "densityOverflow": "{{count}} more — view in Grid",
+  "densityOverflowAria": "Switch to Grid to see {{count}} hidden bookings",
   "nav": {
     "previousDay": "Previous day",
     "previousWeek": "Previous week",

--- a/src/i18n/locales/zh-CN/calendar.json
+++ b/src/i18n/locales/zh-CN/calendar.json
@@ -7,6 +7,8 @@
   "today": "今天",
   "weekOfMonth": "第 {{week}} 周",
   "addBooking": "新增预约",
+  "densityOverflow": "另有 {{count}} 笔，改以 Grid 查看",
+  "densityOverflowAria": "切换到 Grid 以查看未显示的 {{count}} 笔预约",
   "nav": {
     "previousDay": "上一天",
     "previousWeek": "上一周",

--- a/src/i18n/locales/zh-TW/calendar.json
+++ b/src/i18n/locales/zh-TW/calendar.json
@@ -7,6 +7,8 @@
   "today": "今天",
   "weekOfMonth": "第 {{week}} 週",
   "addBooking": "新增預約",
+  "densityOverflow": "另有 {{count}} 筆，改以 Grid 檢視",
+  "densityOverflowAria": "切換到 Grid 以查看未顯示的 {{count}} 筆預約",
   "nav": {
     "previousDay": "上一天",
     "previousWeek": "上一週",

--- a/src/pages/Facility/Booking/BookingCalendar.tsx
+++ b/src/pages/Facility/Booking/BookingCalendar.tsx
@@ -11,6 +11,7 @@ interface BookingCalendarProps {
   onEventClick: (booking: BookingListItem) => void;
   onCancelClick: (booking: BookingListItem) => void;
   onAddSlot: (startLocal: string, endLocal: string) => void;
+  onDensityOverflow: (date: Date) => void;
 }
 
 const toLocalDatetimeValue = (date: Date): string => {
@@ -51,6 +52,7 @@ const BookingCalendar = ({
   onEventClick,
   onCancelClick,
   onAddSlot,
+  onDensityOverflow,
 }: BookingCalendarProps) => {
   const { t } = useTranslation("facility");
   const [calendarLayout, setCalendarLayout] = useState<CalendarView>("week");
@@ -87,7 +89,7 @@ const BookingCalendar = ({
                 : [];
           return {
             id: booking.id,
-            title: booking.userDisplayName || booking.userEmail || booking.facilityName || booking.id,
+            title: booking.userDisplayName || booking.userEmail || "",
             start: booking.startAt,
             end: booking.endAt,
             tags: roomNames,
@@ -126,6 +128,7 @@ const BookingCalendar = ({
           end.setHours(endHour || 10, endMinute || 0, 0, 0);
           onAddSlot(toLocalDatetimeValue(start), toLocalDatetimeValue(end));
         }}
+        onDensityOverflow={onDensityOverflow}
       />
 
       {contextMenu && (

--- a/src/pages/Facility/Booking/BookingDataPage.tsx
+++ b/src/pages/Facility/Booking/BookingDataPage.tsx
@@ -74,16 +74,16 @@ const BookingDataPage = () => {
   const modalRef = useRef<ModalFormHandle>(null);
 
   const setViewMode = useCallback(
-    (next: BookingViewMode) => {
+    (next: BookingViewMode, date?: Date) => {
       const params = new URLSearchParams(searchParams);
       if (next === "list") {
         params.delete("view");
       } else {
         params.set("view", next);
       }
-      if (next === "list") {
-        // List may ignore date; keep or drop — leave date if present for share restore when switching back
-      } else if (!params.get("date")) {
+      if (date) {
+        params.set("date", toIsoDate(date));
+      } else if (next !== "list" && !params.get("date")) {
         params.set("date", toIsoDate(anchorDate));
       }
       setSearchParams(params, { replace: true });
@@ -356,6 +356,7 @@ const BookingDataPage = () => {
                 endAt: localDatetimeInputToDayjs(endLocal),
               });
             }}
+            onDensityOverflow={(date) => setViewMode("grid", date)}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Overlapping admin Calendar bookings were drawn full-width and covered each other. This packs each day-column collision group with greedy columns and a Google Calendar–style card stack (full-width base lane, later lanes overlay with a fixed left indent), so concurrent bookings stay visible and clickable. When a group exceeds the week/day lane cap, a density-overflow control switches Booking to Grid for that date.

Also improves EventBlock time formatting (Google-style ranges), hover tooltip with title/time/venue, and related Calendar ADR / CONTEXT docs.

Closes #11

## Type of change

- [x] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Packer seam: `packDayEventLanes` — collision groups, greedy columns, `left = min(col * INDENT, 1 - MIN_WIDTH)`, `width = 1 - left`; no containment tree.
- Week `K = 4`, Day `K = 10`; overflow control → `view=grid` for that ISO date.
- EventBlock: lane-based z-index, hover tooltip, Google-style time range, venue under time.

## Testing

- [x] `./node_modules/.bin/vitest run src/components/calendar/packDayEventLanes.test.ts src/components/calendar/formatEventTime.test.ts`
- [x] `./node_modules/.bin/tsc -b --noEmit`
- [ ] Manually verify week/day Calendar overlaps, overflow → Grid, and EventBlock tooltip

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)