### PR TITLE
fix: stabilize pointer cursor on links and buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -212,6 +212,15 @@ layer(base);
   [role="button"]:not(:disabled) {
     cursor: pointer;
   }
+  /* Rectangular hit boxes for links; SVG paint holes must not steal hit-testing. */
+  a[href] {
+    display: inline-block;
+  }
+  button svg,
+  [role="button"] svg,
+  a svg {
+    pointer-events: none;
+  }
   body {
     @apply relative font-normal font-outfit z-1 bg-gray-50;
   }


### PR DESCRIPTION
## Summary

Give every `href` link a rectangular hit box and ignore pointer events on SVG descendants of buttons and anchors, so Chromium no longer flickers the cursor between pointer and arrow while moving across admin chrome.

Closes #15

## Type of change

- [x] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Host-only `@layer base` change in `src/index.css`. The existing enabled-button `cursor: pointer` rule is unchanged. Utility classes such as `flex`, `block`, and `inline-flex` still override the link display rule, so sidebar items and logos keep their layout. Library Button `transition` is out of scope (tracked on newlife-ui#32).

## Testing

- [x] `pnpm run type-check`
- [ ] Manual Chromium: move the pointer slowly across sidebar items, header app-name, DataTable toolbar and sortable headers, Calendar booking events, ModalForm submit/cancel, and Sign in; cursor must stay pointer and must not flicker while still. Confirm flex layout links (sidebar logo) did not jump.

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)