### PR TITLE
feat: Booking Grid 24-hour 30-minute occupancy map

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,30 @@ _Avoid_: representative + `+N` list as the v1 Calendar layout, stacking full-wid
 The control on a Calendar collision group when the group needs more lanes than K. It shows how many events were not drawn and switches Booking view mode to `grid` for that date. It is not a list of the hidden bookings.
 _Avoid_: popover of remainder bookings, silent truncation, opening the representative's detail from this control
 
+**Booking Grid**:
+The admin day-scoped occupancy map: rooms as frozen rows, time as a horizontally scrollable 00:00–24:00 axis. It is not Calendar-with-rooms and not the List DataTable.
+_Avoid_: Calendar week/day layout rules, Primary-only row placement, stretching hour columns to fill the viewport
+
+**Grid cell**:
+One 30-minute create target on Booking Grid. There are 48 cells per day; the last is 23:30–24:00. The trailing 12:00 AM label is not a cell.
+_Avoid_: 60-minute cells, a 49th cell at 24:00, Room slot template duration as cell size
+
+**Grid occupancy block**:
+A continuous bar for one booking on one room row, from Booking start / Booking end clipped to the Grid day window. Multi-room bookings reuse the same interval on every `facilityIds` row.
+_Avoid_: discrete timetable cell fill, per-room intervals on the same booking, matching rooms by `facilityNames`
+
+**Grid day window**:
+The operator-local half-open day `[00:00, 24:00)` of the Booking Grid anchor date. Same local-day rule as Calendar.
+_Avoid_: facility timezone as the day boundary, an 08:00–22:00 window
+
+**Primary facility**:
+The first room line on a booking (`facilityId` on the list item). List room filters use this key. Booking Grid occupancy uses `facilityIds` (with Primary fallback), not Primary alone.
+_Avoid_: treating Primary as the only occupied room on Grid
+
+**Booking view mode**:
+Which admin booking surface is active: `list`, `calendar`, or `grid` (URL/`view` state).
+_Avoid_: conflating Calendar packing with Grid occupancy
+
 **DataTable**:
 The Portal admin list shell built on `@efcnewlife/newlife-ui` Table primitives, plus pagination, sorting, row selection, and context menu. It is a host composite, not the library Table itself.
 _Avoid_: Table (when meaning the Portal list page), DataGrid, Grid

--- a/docs/adr/0001-calendar-concurrent-booking-lanes.md
+++ b/docs/adr/0001-calendar-concurrent-booking-lanes.md
@@ -22,7 +22,7 @@ Lay out overlapping Calendar booking events as a right-aligned card stack: the e
 - Visible lanes are the first K from greedy packing. Events assigned column index `>= K` are omitted. Overflow layout still uses each visible event's real `col` for indent (not `col / n`).
 - Calendar density overflow is a control on that overflowing group. Its label includes N (undrawn count). Activating it switches Booking view mode to `grid` and sets `date` to that day column's ISO date. It does not open detail, a context menu, or a remainder list.
 - One Calendar booking event per booking id; title is the Booker. Cancelled bookings stay off Calendar. Midnight-spanning bookings continue across day columns, with packing computed per day.
-- Month view is unused by booking Calendar and stays as-is. List and Grid views are unchanged.
+- Month view is unused by booking Calendar and stays as-is. List view is unchanged. Booking Grid layout is governed by ADR 0002 (this ADR’s former “Grid unchanged” clause is superseded for Grid only).
 
 ## Consequences
 

--- a/docs/adr/0002-booking-grid-24h-occupancy-map.md
+++ b/docs/adr/0002-booking-grid-24h-occupancy-map.md
@@ -1,0 +1,31 @@
+# 0002. Booking Grid is a 24-hour 30-minute freeze-pane occupancy map
+
+## Status
+
+Accepted
+
+## Context
+
+Admin Booking Grid previously showed only 08:00–22:00 in one-hour cells that stretched to fill the viewport. Overnight and half-hour bookings were clipped or misaligned, and the time axis rarely scrolled. Multi-room bookings appeared only on Primary facility, so other occupied room rows looked free.
+
+ADR 0001 still governs Calendar. Its “Grid unchanged” note is superseded for Booking Grid only by this decision.
+
+## Decision
+
+Treat Booking Grid as the single-day occupancy map for one operator-local calendar day:
+
+- Rooms are frozen rows; time is a horizontally scrollable 00:00–24:00 axis with 48 half-hour Grid cells. The trailing 12:00 AM is an axis label, not a 49th cell. Last cell is 23:30–24:00.
+- Occupancy is a continuous bar from Booking start / Booking end (percent of the 24-hour span), clipped to the Grid day window `[00:00, 24:00)`. Do not fill discrete cells.
+- Hour labels always use 12-hour AM/PM (not locale 24-hour). Both ends are labelled 12:00 AM. Half-hour columns have a line and no text.
+- One booking has one interval. Draw that interval on every room id in `facilityIds`. If `facilityIds` is empty, fall back to Primary `facilityId`. Do not match rooms by `facilityNames`.
+- Cancelled bookings stay off Booking Grid. Other statuses stay on, matching Calendar.
+- Freeze pane: one scrollport; room column sticky left; time header sticky top and coupled to the time columns. Default horizontal offset lands near 8:00 AM. Column min-width must force horizontal overflow (no stretching `1fr` as the only sizing).
+- Click empty cell: prefill that 30 minutes (including 23:30–24:00 as next local midnight). Empty cells are disabled without create permission.
+- Admin list items include `facilityIds` (core-api) so Grid does not infer rooms from names. List Primary filter and `facilityNames` stay unchanged.
+
+## Consequences
+
+- Operators can read a full local day of occupancy, including overnight clips and 30-minute alignment.
+- Multi-room bookings no longer look free on secondary room rows.
+- Calendar layout, packing, K, and density overflow stay under ADR 0001; density overflow still opens Booking Grid on that date.
+- Do not restore 08:00–22:00, 1-hour cells, or Primary-only Grid placement without superseding this ADR.

--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -320,6 +320,7 @@ export interface BookingListItem {
   userDisplayName?: string;
   facilityId?: string;
   facilityName?: string;
+  facilityIds?: string[];
   facilityNames?: string[];
   bookingType: string;
   startAt: string;

--- a/src/components/common/ManagementPage.tsx
+++ b/src/components/common/ManagementPage.tsx
@@ -18,9 +18,9 @@ const ManagementPage: React.FC<ManagementPageProps> = ({ title, description, chi
   }, [title, setPageTitle]);
 
   return (
-    <div className="flex flex-col h-[calc(100vh-120px)] gap-3">
+    <div className="flex h-[calc(100vh-120px)] min-w-0 w-full max-w-full flex-col gap-3">
       <PageMeta title={title} description={description} />
-      <div className="flex-1 min-h-0">{children}</div>
+      <div className="min-h-0 min-w-0 w-full flex-1">{children}</div>
     </div>
   );
 };

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -14,12 +14,12 @@ const LayoutContent: React.FC = () => {
       <AppSidebar />
       <Backdrop />
       <div
-        className={`flex-1 transition-all duration-300 ease-in-out ${isExpanded ? "xl:ml-[290px]" : "xl:ml-[90px]"} ${
+        className={`min-w-0 flex-1 transition-all duration-300 ease-in-out ${isExpanded ? "xl:ml-[290px]" : "xl:ml-[90px]"} ${
           isMobileOpen ? "ml-0" : ""
         }`}
       >
         <AppHeader />
-        <div className="p-4 mx-auto md:p-6">
+        <div className="mx-auto min-w-0 max-w-full overflow-x-hidden p-4 md:p-6">
           <Outlet />
         </div>
       </div>

--- a/src/pages/Facility/Booking/BookingDataPage.tsx
+++ b/src/pages/Facility/Booking/BookingDataPage.tsx
@@ -293,7 +293,7 @@ const BookingDataPage = () => {
   const showScheduleCreate = (viewMode === "calendar" || viewMode === "grid") && canCreate;
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3">
+    <div className="flex h-full min-h-0 min-w-0 w-full flex-col gap-3 overflow-hidden">
       <PageToolbar
         left={
           showScheduleCreate ? (
@@ -362,7 +362,7 @@ const BookingDataPage = () => {
       )}
 
       {viewMode === "grid" && (
-        <div className="min-h-0 flex-1">
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
           <BookingGrid
             anchorDate={anchorDate}
             rooms={rooms}

--- a/src/pages/Facility/Booking/BookingGrid.tsx
+++ b/src/pages/Facility/Booking/BookingGrid.tsx
@@ -2,15 +2,22 @@ import type { BookingListItem } from "@/api/services/facilityService";
 import NavigationButtons from "@/components/calendar/NavigationButtons";
 import { formatDate, formatWeekday } from "@/components/calendar/utils";
 import { cn } from "@/utils";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  GRID_CELL_COUNT,
+  clickIntervalForCell,
+  defaultViewportScrollRatio,
+  formatGridCellStartLabel,
+  formatGridHourLabel,
+  gridHourLabels,
+  layoutGridOccupancyBlocks,
+  toLocalDatetimeValue,
+} from "./bookingGridLayout";
 
-const GRID_START_HOUR = 8;
-const GRID_END_HOUR = 22;
-const HOUR_COLUMNS = Array.from({ length: GRID_END_HOUR - GRID_START_HOUR }, (_, i) => GRID_START_HOUR + i);
-const WINDOW_START_MINUTES = GRID_START_HOUR * 60;
-const WINDOW_END_MINUTES = GRID_END_HOUR * 60;
-const WINDOW_SPAN_MINUTES = WINDOW_END_MINUTES - WINDOW_START_MINUTES;
+const CELL_MIN_WIDTH_REM = 2.75;
+const ROOM_COLUMN_WIDTH_CLASS = "w-40";
+const ROOM_COLUMN_WIDTH_PX = 160;
 
 interface BookingGridProps {
   anchorDate: Date;
@@ -25,9 +32,6 @@ interface BookingGridProps {
 
 const pad = (n: number): string => String(n).padStart(2, "0");
 
-const toLocalDatetimeValue = (date: Date): string =>
-  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-
 const startOfDay = (date: Date): Date => {
   const next = new Date(date);
   next.setHours(0, 0, 0, 0);
@@ -40,105 +44,7 @@ const endOfDay = (date: Date): Date => {
   return next;
 };
 
-const minutesFromMidnight = (date: Date): number => date.getHours() * 60 + date.getMinutes();
-
-const formatHourLabel = (hour: number, locale: string): string => {
-  const date = new Date();
-  date.setHours(hour, 0, 0, 0);
-  return date.toLocaleTimeString(locale, {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: locale.startsWith("en"),
-  });
-};
-
 const roomLabel = (room: { code: string; name?: string }): string => room.name || room.code;
-
-interface GridBlockLayout {
-  booking: BookingListItem;
-  leftPercent: number;
-  widthPercent: number;
-  startMinutes: number;
-  endMinutes: number;
-  lane: number;
-  laneCount: number;
-}
-
-const assignOverlapLanes = (blocks: Omit<GridBlockLayout, "lane" | "laneCount">[]): GridBlockLayout[] => {
-  const sorted = [...blocks].sort((a, b) => a.startMinutes - b.startMinutes || a.endMinutes - b.endMinutes);
-  const laneEnds: number[] = [];
-  const withLanes = sorted.map((block) => {
-    let lane = laneEnds.findIndex((end) => end <= block.startMinutes);
-    if (lane === -1) {
-      lane = laneEnds.length;
-      laneEnds.push(block.endMinutes);
-    } else {
-      laneEnds[lane] = block.endMinutes;
-    }
-    return { ...block, lane, laneCount: 1 };
-  });
-
-  // Cluster overlapping groups so laneCount reflects local stack depth.
-  for (let i = 0; i < withLanes.length; i++) {
-    let clusterEnd = withLanes[i].endMinutes;
-    let maxLane = withLanes[i].lane;
-    let j = i + 1;
-    while (j < withLanes.length && withLanes[j].startMinutes < clusterEnd) {
-      clusterEnd = Math.max(clusterEnd, withLanes[j].endMinutes);
-      maxLane = Math.max(maxLane, withLanes[j].lane);
-      j++;
-    }
-    const laneCount = maxLane + 1;
-    for (let k = i; k < j; k++) {
-      withLanes[k].laneCount = laneCount;
-    }
-    i = j - 1;
-  }
-
-  return withLanes;
-};
-
-const layoutBlocksForRoom = (
-  bookings: BookingListItem[],
-  roomId: string,
-  day: Date
-): GridBlockLayout[] => {
-  const dayStart = startOfDay(day);
-  const dayEnd = endOfDay(day);
-  const windowStart = new Date(day);
-  windowStart.setHours(GRID_START_HOUR, 0, 0, 0);
-  const windowEnd = new Date(day);
-  windowEnd.setHours(GRID_END_HOUR, 0, 0, 0);
-
-  const placed = bookings
-    .filter((booking) => booking.status !== "cancelled")
-    .filter((booking) => booking.facilityId === roomId)
-    .map((booking) => {
-      const start = new Date(booking.startAt);
-      const end = new Date(booking.endAt);
-      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
-      if (end <= dayStart || start > dayEnd) return null;
-
-      const clampedStart = start < windowStart ? windowStart : start;
-      const clampedEnd = end > windowEnd ? windowEnd : end;
-      if (clampedEnd <= clampedStart) return null;
-
-      const startMinutes = Math.max(minutesFromMidnight(clampedStart), WINDOW_START_MINUTES);
-      const endMinutes = Math.min(minutesFromMidnight(clampedEnd), WINDOW_END_MINUTES);
-      if (endMinutes <= startMinutes) return null;
-
-      return {
-        booking,
-        leftPercent: ((startMinutes - WINDOW_START_MINUTES) / WINDOW_SPAN_MINUTES) * 100,
-        widthPercent: ((endMinutes - startMinutes) / WINDOW_SPAN_MINUTES) * 100,
-        startMinutes,
-        endMinutes,
-      };
-    })
-    .filter((item): item is Omit<GridBlockLayout, "lane" | "laneCount"> => item !== null);
-
-  return assignOverlapLanes(placed);
-};
 
 const BookingGrid = ({
   anchorDate,
@@ -150,20 +56,31 @@ const BookingGrid = ({
   onBookingClick,
   onAddCell,
 }: BookingGridProps) => {
-  const { t, i18n } = useTranslation("facility");
-  const locale = i18n.language || "en";
+  const { t } = useTranslation("facility");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const hourLabels = useMemo(() => gridHourLabels(), []);
+  const cellIndexes = useMemo(() => Array.from({ length: GRID_CELL_COUNT }, (_, index) => index), []);
 
   useEffect(() => {
     onVisibleRangeChange({ start: startOfDay(anchorDate), end: endOfDay(anchorDate) });
   }, [anchorDate, onVisibleRangeChange]);
 
-  const blocksByRoom = useMemo(() => {
-    const map = new Map<string, GridBlockLayout[]>();
-    for (const room of rooms) {
-      map.set(room.id, layoutBlocksForRoom(bookings, room.id, anchorDate));
-    }
-    return map;
-  }, [anchorDate, bookings, rooms]);
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    const applyDefaultScroll = () => {
+      const timeWidth = Math.max(0, node.scrollWidth - ROOM_COLUMN_WIDTH_PX);
+      if (timeWidth <= 0) return;
+      node.scrollLeft = defaultViewportScrollRatio() * timeWidth;
+    };
+    applyDefaultScroll();
+    requestAnimationFrame(applyDefaultScroll);
+  }, [anchorDate, rooms.length]);
+
+  const blocksByRoom = useMemo(
+    () => layoutGridOccupancyBlocks(bookings, rooms, anchorDate),
+    [anchorDate, bookings, rooms]
+  );
 
   const shiftDay = (delta: number) => {
     const next = new Date(anchorDate);
@@ -171,13 +88,14 @@ const BookingGrid = ({
     onAnchorDateChange(next);
   };
 
-  const handleCellClick = (facilityId: string, hour: number) => {
+  const handleCellClick = (facilityId: string, cellIndex: number) => {
     if (!canCreate) return;
-    const start = new Date(anchorDate);
-    start.setHours(hour, 0, 0, 0);
-    const end = new Date(anchorDate);
-    end.setHours(hour + 1, 0, 0, 0);
+    const { start, end } = clickIntervalForCell(anchorDate, cellIndex);
     onAddCell(facilityId, toLocalDatetimeValue(start), toLocalDatetimeValue(end));
+  };
+
+  const timeColumnsStyle = {
+    gridTemplateColumns: `repeat(${GRID_CELL_COUNT}, minmax(${CELL_MIN_WIDTH_REM}rem, ${CELL_MIN_WIDTH_REM}rem))`,
   };
 
   return (
@@ -202,24 +120,39 @@ const BookingGrid = ({
         />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto bg-white dark:bg-gray-900">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto bg-white dark:bg-gray-900">
         {rooms.length === 0 ? (
           <p className="px-6 py-8 text-sm text-gray-500 dark:text-gray-400">{t("booking.grid.noRooms")}</p>
         ) : (
-          <div className="min-w-[720px]">
+          <div className="relative inline-block min-w-full">
             <div className="sticky top-0 z-20 flex border-b border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-gray-800/80">
-              <div className="sticky left-0 z-30 flex w-40 shrink-0 items-center border-r border-gray-200 bg-gray-50 px-3 py-2 text-xs font-medium text-gray-500 dark:border-white/10 dark:bg-gray-800/80 dark:text-gray-400">
+              <div
+                className={cn(
+                  "sticky left-0 z-30 flex shrink-0 items-center border-r border-gray-200 bg-gray-50 px-3 py-2 text-xs font-medium text-gray-500 dark:border-white/10 dark:bg-gray-800/80 dark:text-gray-400",
+                  ROOM_COLUMN_WIDTH_CLASS
+                )}
+              >
                 {t("booking.grid.room")}
               </div>
-              <div className="grid min-w-0 flex-1" style={{ gridTemplateColumns: `repeat(${HOUR_COLUMNS.length}, minmax(3.5rem, 1fr))` }}>
-                {HOUR_COLUMNS.map((hour) => (
-                  <div
-                    key={hour}
-                    className="border-r border-gray-200 px-1 py-2 text-center text-xs font-medium text-gray-500 last:border-r-0 dark:border-white/10 dark:text-gray-400"
-                  >
-                    {formatHourLabel(hour, locale)}
-                  </div>
-                ))}
+              <div className="relative grid" style={timeColumnsStyle}>
+                {cellIndexes.map((cellIndex) => {
+                  const isHourStart = cellIndex % 2 === 0;
+                  const hour = cellIndex / 2;
+                  return (
+                    <div
+                      key={cellIndex}
+                      className={cn(
+                        "border-r border-gray-200 px-0.5 py-2 text-center text-[10px] font-medium text-gray-500 dark:border-white/10 dark:text-gray-400",
+                        cellIndex === GRID_CELL_COUNT - 1 && "border-r-0"
+                      )}
+                    >
+                      {isHourStart ? hourLabels[hour] : null}
+                    </div>
+                  );
+                })}
+                <span className="pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 whitespace-nowrap text-[10px] font-medium text-gray-500 dark:text-gray-400">
+                  {formatGridHourLabel(24)}
+                </span>
               </div>
             </div>
 
@@ -227,42 +160,49 @@ const BookingGrid = ({
               const blocks = blocksByRoom.get(room.id) || [];
               return (
                 <div key={room.id} className="flex border-b border-gray-100 dark:border-white/5">
-                  <div className="sticky left-0 z-10 flex w-40 shrink-0 items-center border-r border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-800 dark:border-white/10 dark:bg-gray-900 dark:text-gray-100">
+                  <div
+                    className={cn(
+                      "sticky left-0 z-10 flex shrink-0 items-center border-r border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-800 dark:border-white/10 dark:bg-gray-900 dark:text-gray-100",
+                      ROOM_COLUMN_WIDTH_CLASS
+                    )}
+                  >
                     <span className="truncate" title={roomLabel(room)}>
                       {roomLabel(room)}
                     </span>
                   </div>
-                  <div className="relative min-w-0 flex-1">
-                    <div className="grid h-14" style={{ gridTemplateColumns: `repeat(${HOUR_COLUMNS.length}, minmax(3.5rem, 1fr))` }}>
-                      {HOUR_COLUMNS.map((hour) => (
-                        <button
-                          key={hour}
-                          type="button"
-                          disabled={!canCreate}
-                          aria-label={t("booking.grid.addSlot", {
-                            room: roomLabel(room),
-                            hour: formatHourLabel(hour, locale),
-                          })}
-                          className={cn(
-                            "border-r border-gray-100 last:border-r-0 dark:border-white/5",
-                            canCreate && "hover:bg-brand-50/60 dark:hover:bg-brand-500/10",
-                            !canCreate && "cursor-default"
-                          )}
-                          onClick={() => handleCellClick(room.id, hour)}
-                        />
-                      ))}
+                  <div className="relative">
+                    <div className="grid h-14" style={timeColumnsStyle}>
+                      {cellIndexes.map((cellIndex) => (
+                          <button
+                            key={cellIndex}
+                            type="button"
+                            disabled={!canCreate}
+                            aria-label={t("booking.grid.addSlot", {
+                              room: roomLabel(room),
+                              hour: formatGridCellStartLabel(cellIndex),
+                            })}
+                            className={cn(
+                              "border-r border-gray-100 dark:border-white/5",
+                              cellIndex % 2 === 1 && "border-r-gray-200/80 dark:border-r-white/10",
+                              cellIndex === GRID_CELL_COUNT - 1 && "border-r-0",
+                              canCreate && "hover:bg-brand-50/60 dark:hover:bg-brand-500/10",
+                              !canCreate && "cursor-default"
+                            )}
+                            onClick={() => handleCellClick(room.id, cellIndex)}
+                          />
+                        ))}
                     </div>
                     {blocks.map(({ booking, leftPercent, widthPercent, lane, laneCount }) => {
                       const topPercent = (lane / laneCount) * 100;
                       const heightPercent = 100 / laneCount;
                       return (
                         <button
-                          key={booking.id}
+                          key={`${booking.id}-${room.id}`}
                           type="button"
                           className="absolute z-[1] overflow-hidden rounded-md border border-brand-200 bg-brand-50 px-1.5 py-0.5 text-left hover:bg-brand-100 dark:border-brand-500/40 dark:bg-brand-500/20 dark:hover:bg-brand-500/30"
                           style={{
                             left: `${leftPercent}%`,
-                            width: `${Math.max(widthPercent, 2)}%`,
+                            width: `${Math.max(widthPercent, 0.4)}%`,
                             top: `calc(${topPercent}% + 2px)`,
                             height: `calc(${heightPercent}% - 4px)`,
                           }}

--- a/src/pages/Facility/Booking/BookingGrid.tsx
+++ b/src/pages/Facility/Booking/BookingGrid.tsx
@@ -6,18 +6,19 @@ import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   GRID_CELL_COUNT,
+  GRID_DAY_MINUTES,
   clickIntervalForCell,
   defaultViewportScrollRatio,
   formatGridCellStartLabel,
   formatGridHourLabel,
-  gridHourLabels,
   layoutGridOccupancyBlocks,
   toLocalDatetimeValue,
 } from "./bookingGridLayout";
 
 const CELL_MIN_WIDTH_REM = 2.75;
 const ROOM_COLUMN_WIDTH_CLASS = "w-40";
-const ROOM_COLUMN_WIDTH_PX = 160;
+const TIME_TRACK_WIDTH = `calc(${GRID_CELL_COUNT} * ${CELL_MIN_WIDTH_REM}rem)`;
+const HOUR_TICKS = Array.from({ length: 25 }, (_, hour) => hour);
 
 interface BookingGridProps {
   anchorDate: Date;
@@ -57,8 +58,9 @@ const BookingGrid = ({
   onAddCell,
 }: BookingGridProps) => {
   const { t } = useTranslation("facility");
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const hourLabels = useMemo(() => gridHourLabels(), []);
+  const roomsScrollRef = useRef<HTMLDivElement>(null);
+  const timeScrollRef = useRef<HTMLDivElement>(null);
+  const syncingScroll = useRef(false);
   const cellIndexes = useMemo(() => Array.from({ length: GRID_CELL_COUNT }, (_, index) => index), []);
 
   useEffect(() => {
@@ -66,16 +68,30 @@ const BookingGrid = ({
   }, [anchorDate, onVisibleRangeChange]);
 
   useEffect(() => {
-    const node = scrollRef.current;
+    const node = timeScrollRef.current;
     if (!node) return;
     const applyDefaultScroll = () => {
-      const timeWidth = Math.max(0, node.scrollWidth - ROOM_COLUMN_WIDTH_PX);
-      if (timeWidth <= 0) return;
-      node.scrollLeft = defaultViewportScrollRatio() * timeWidth;
+      node.scrollLeft = defaultViewportScrollRatio() * node.scrollWidth;
     };
     applyDefaultScroll();
     requestAnimationFrame(applyDefaultScroll);
   }, [anchorDate, rooms.length]);
+
+  const syncVerticalScroll = (source: "rooms" | "time") => {
+    if (syncingScroll.current) return;
+    const roomsNode = roomsScrollRef.current;
+    const timeNode = timeScrollRef.current;
+    if (!roomsNode || !timeNode) return;
+    syncingScroll.current = true;
+    if (source === "rooms") {
+      timeNode.scrollTop = roomsNode.scrollTop;
+    } else {
+      roomsNode.scrollTop = timeNode.scrollTop;
+    }
+    requestAnimationFrame(() => {
+      syncingScroll.current = false;
+    });
+  };
 
   const blocksByRoom = useMemo(
     () => layoutGridOccupancyBlocks(bookings, rooms, anchorDate),
@@ -95,11 +111,12 @@ const BookingGrid = ({
   };
 
   const timeColumnsStyle = {
+    width: TIME_TRACK_WIDTH,
     gridTemplateColumns: `repeat(${GRID_CELL_COUNT}, minmax(${CELL_MIN_WIDTH_REM}rem, ${CELL_MIN_WIDTH_REM}rem))`,
   };
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-gray-300 dark:border-white/10">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-gray-300 dark:border-white/10">
       <div className="flex flex-none items-center justify-between border-b border-gray-300 bg-gray-200 px-4 py-3 dark:border-white/10 dark:bg-gray-800/50 sm:px-6">
         <div>
           <h2 className="text-base font-semibold text-gray-900 dark:text-white">
@@ -120,77 +137,86 @@ const BookingGrid = ({
         />
       </div>
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto bg-white dark:bg-gray-900">
-        {rooms.length === 0 ? (
-          <p className="px-6 py-8 text-sm text-gray-500 dark:text-gray-400">{t("booking.grid.noRooms")}</p>
-        ) : (
-          <div className="relative inline-block min-w-full">
-            <div className="sticky top-0 z-20 flex border-b border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-gray-800/80">
-              <div
-                className={cn(
-                  "sticky left-0 z-30 flex shrink-0 items-center border-r border-gray-200 bg-gray-50 px-3 py-2 text-xs font-medium text-gray-500 dark:border-white/10 dark:bg-gray-800/80 dark:text-gray-400",
-                  ROOM_COLUMN_WIDTH_CLASS
-                )}
-              >
-                {t("booking.grid.room")}
-              </div>
-              <div className="relative grid" style={timeColumnsStyle}>
-                {cellIndexes.map((cellIndex) => {
-                  const isHourStart = cellIndex % 2 === 0;
-                  const hour = cellIndex / 2;
-                  return (
-                    <div
-                      key={cellIndex}
-                      className={cn(
-                        "border-r border-gray-200 px-0.5 py-2 text-center text-[10px] font-medium text-gray-500 dark:border-white/10 dark:text-gray-400",
-                        cellIndex === GRID_CELL_COUNT - 1 && "border-r-0"
-                      )}
-                    >
-                      {isHourStart ? hourLabels[hour] : null}
-                    </div>
-                  );
-                })}
-                <span className="pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 whitespace-nowrap text-[10px] font-medium text-gray-500 dark:text-gray-400">
-                  {formatGridHourLabel(24)}
-                </span>
-              </div>
+      {rooms.length === 0 ? (
+        <p className="px-6 py-8 text-sm text-gray-500 dark:text-gray-400">{t("booking.grid.noRooms")}</p>
+      ) : (
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden bg-white dark:bg-gray-900">
+          <div
+            className={cn(
+              "flex shrink-0 flex-col border-r border-gray-200 bg-white dark:border-white/10 dark:bg-gray-900",
+              ROOM_COLUMN_WIDTH_CLASS
+            )}
+          >
+            <div className="flex h-9 shrink-0 items-center border-b border-gray-200 bg-gray-50 px-3 text-xs font-medium text-gray-500 dark:border-white/10 dark:bg-gray-800/80 dark:text-gray-400">
+              {t("booking.grid.room")}
             </div>
+            <div
+              ref={roomsScrollRef}
+              className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              onScroll={() => syncVerticalScroll("rooms")}
+            >
+              {rooms.map((room) => (
+                <div
+                  key={room.id}
+                  className="flex h-14 items-center border-b border-gray-100 px-3 text-sm font-medium text-gray-800 dark:border-white/5 dark:text-gray-100"
+                >
+                  <span className="truncate" title={roomLabel(room)}>
+                    {roomLabel(room)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
 
-            {rooms.map((room) => {
-              const blocks = blocksByRoom.get(room.id) || [];
-              return (
-                <div key={room.id} className="flex border-b border-gray-100 dark:border-white/5">
-                  <div
-                    className={cn(
-                      "sticky left-0 z-10 flex shrink-0 items-center border-r border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-800 dark:border-white/10 dark:bg-gray-900 dark:text-gray-100",
-                      ROOM_COLUMN_WIDTH_CLASS
-                    )}
-                  >
-                    <span className="truncate" title={roomLabel(room)}>
-                      {roomLabel(room)}
+          <div
+            ref={timeScrollRef}
+            className="w-0 min-w-0 flex-1 overflow-x-auto overflow-y-auto"
+            onScroll={() => syncVerticalScroll("time")}
+          >
+            <div style={{ width: TIME_TRACK_WIDTH }}>
+              <div className="sticky top-0 z-20 h-9 border-b border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-gray-800/80">
+                <div className="relative h-full" style={{ width: TIME_TRACK_WIDTH }}>
+                  {HOUR_TICKS.map((hour) => (
+                    <span
+                      key={hour}
+                      className={cn(
+                        "pointer-events-none absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-[10px] font-medium text-gray-500 dark:text-gray-400",
+                        hour === 0 && "translate-x-0",
+                        hour === 24 && "-translate-x-full",
+                        hour !== 0 && hour !== 24 && "-translate-x-1/2"
+                      )}
+                      style={{ left: `${((hour * 60) / GRID_DAY_MINUTES) * 100}%` }}
+                    >
+                      {formatGridHourLabel(hour)}
                     </span>
-                  </div>
-                  <div className="relative">
-                    <div className="grid h-14" style={timeColumnsStyle}>
+                  ))}
+                </div>
+              </div>
+
+              {rooms.map((room) => {
+                const blocks = blocksByRoom.get(room.id) || [];
+                return (
+                  <div key={room.id} className="relative h-14 border-b border-gray-100 dark:border-white/5">
+                    <div className="grid h-full" style={timeColumnsStyle}>
                       {cellIndexes.map((cellIndex) => (
-                          <button
-                            key={cellIndex}
-                            type="button"
-                            disabled={!canCreate}
-                            aria-label={t("booking.grid.addSlot", {
-                              room: roomLabel(room),
-                              hour: formatGridCellStartLabel(cellIndex),
-                            })}
-                            className={cn(
-                              "border-r border-gray-100 dark:border-white/5",
-                              cellIndex % 2 === 1 && "border-r-gray-200/80 dark:border-r-white/10",
-                              cellIndex === GRID_CELL_COUNT - 1 && "border-r-0",
-                              canCreate && "hover:bg-brand-50/60 dark:hover:bg-brand-500/10",
-                              !canCreate && "cursor-default"
-                            )}
-                            onClick={() => handleCellClick(room.id, cellIndex)}
-                          />
-                        ))}
+                        <button
+                          key={cellIndex}
+                          type="button"
+                          disabled={!canCreate}
+                          aria-label={t("booking.grid.addSlot", {
+                            room: roomLabel(room),
+                            hour: formatGridCellStartLabel(cellIndex),
+                          })}
+                          className={cn(
+                            "border-r border-gray-100 dark:border-white/5",
+                            cellIndex % 2 === 1 && "border-r-gray-200/80 dark:border-r-white/10",
+                            cellIndex === GRID_CELL_COUNT - 1 && "border-r-0",
+                            canCreate && "hover:bg-brand-50/60 dark:hover:bg-brand-500/10",
+                            !canCreate && "cursor-default"
+                          )}
+                          onClick={() => handleCellClick(room.id, cellIndex)}
+                        />
+                      ))}
                     </div>
                     {blocks.map(({ booking, leftPercent, widthPercent, lane, laneCount }) => {
                       const topPercent = (lane / laneCount) * 100;
@@ -219,12 +245,12 @@ const BookingGrid = ({
                       );
                     })}
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/Facility/Booking/bookingGridLayout.test.ts
+++ b/src/pages/Facility/Booking/bookingGridLayout.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import type { BookingListItem } from "@/api/services/facilityService";
+import {
+  DEFAULT_VIEWPORT_MINUTE,
+  GRID_CELL_COUNT,
+  GRID_CELL_MINUTES,
+  GRID_DAY_MINUTES,
+  clickIntervalForCell,
+  formatGridCellStartLabel,
+  formatGridHourLabel,
+  gridHourLabels,
+  layoutGridOccupancyBlocks,
+  occupiedFacilityIds,
+} from "./bookingGridLayout";
+
+const at = (year: number, month: number, day: number, hour: number, minute = 0): Date =>
+  new Date(year, month, day, hour, minute, 0, 0);
+
+const booking = (overrides: Partial<BookingListItem> & Pick<BookingListItem, "id" | "startAt" | "endAt">): BookingListItem => ({
+  userId: "user-1",
+  bookingType: "one_time",
+  status: "confirmed",
+  ...overrides,
+});
+
+describe("bookingGridLayout", () => {
+  it("exposes 48 half-hour cells across a 24-hour day", () => {
+    expect(GRID_CELL_MINUTES).toBe(30);
+    expect(GRID_DAY_MINUTES).toBe(24 * 60);
+    expect(GRID_CELL_COUNT).toBe(48);
+    expect(DEFAULT_VIEWPORT_MINUTE).toBe(8 * 60);
+  });
+
+  it("maps the last cell to 11:30 PM–12:00 AM", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const interval = clickIntervalForCell(day, 47);
+    expect(interval.start).toEqual(at(2026, 7, 20, 23, 30));
+    expect(interval.end).toEqual(at(2026, 7, 21, 0, 0));
+  });
+
+  it("maps cell 0 to 12:00 AM–12:30 AM", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const interval = clickIntervalForCell(day, 0);
+    expect(interval.start).toEqual(at(2026, 7, 20, 0, 0));
+    expect(interval.end).toEqual(at(2026, 7, 20, 0, 30));
+  });
+
+  it("formats hour labels in 12-hour AM/PM with both ends 12:00 AM", () => {
+    expect(formatGridHourLabel(0)).toBe("12:00 AM");
+    expect(formatGridHourLabel(12)).toBe("12:00 PM");
+    expect(formatGridHourLabel(13)).toBe("1:00 PM");
+    expect(formatGridHourLabel(24)).toBe("12:00 AM");
+    const labels = gridHourLabels();
+    expect(labels).toHaveLength(25);
+    expect(labels[0]).toBe("12:00 AM");
+    expect(labels[24]).toBe("12:00 AM");
+  });
+
+  it("formats half-hour cell start labels for create targets", () => {
+    expect(formatGridCellStartLabel(0)).toBe("12:00 AM");
+    expect(formatGridCellStartLabel(21)).toBe("10:30 AM");
+    expect(formatGridCellStartLabel(47)).toBe("11:30 PM");
+  });
+
+  it("places a continuous bar for unaligned start and end", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const roomId = "room-a";
+    const blocks = layoutGridOccupancyBlocks(
+      [
+        booking({
+          id: "b1",
+          facilityIds: [roomId],
+          startAt: at(2026, 7, 20, 10, 15).toISOString(),
+          endAt: at(2026, 7, 20, 11, 45).toISOString(),
+        }),
+      ],
+      [{ id: roomId }],
+      day
+    );
+    const [block] = blocks.get(roomId) || [];
+    expect(block).toBeDefined();
+    expect(block.leftPercent).toBeCloseTo((10 * 60 + 15) / GRID_DAY_MINUTES * 100);
+    expect(block.widthPercent).toBeCloseTo(90 / GRID_DAY_MINUTES * 100);
+  });
+
+  it("clips occupancy at both midnights", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const roomId = "room-a";
+    const blocks = layoutGridOccupancyBlocks(
+      [
+        booking({
+          id: "overnight",
+          facilityIds: [roomId],
+          startAt: at(2026, 7, 19, 22, 0).toISOString(),
+          endAt: at(2026, 7, 20, 2, 0).toISOString(),
+        }),
+      ],
+      [{ id: roomId }],
+      day
+    );
+    const [block] = blocks.get(roomId) || [];
+    expect(block.leftPercent).toBe(0);
+    expect(block.widthPercent).toBeCloseTo((2 * 60) / GRID_DAY_MINUTES * 100);
+  });
+
+  it("duplicates the same interval onto every facilityIds row", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const rooms = [{ id: "r1" }, { id: "r2" }, { id: "r3" }];
+    const blocks = layoutGridOccupancyBlocks(
+      [
+        booking({
+          id: "multi",
+          facilityId: "r1",
+          facilityIds: ["r1", "r2"],
+          startAt: at(2026, 7, 20, 9, 0).toISOString(),
+          endAt: at(2026, 7, 20, 10, 0).toISOString(),
+        }),
+      ],
+      rooms,
+      day
+    );
+    expect(blocks.get("r1")).toHaveLength(1);
+    expect(blocks.get("r2")).toHaveLength(1);
+    expect(blocks.get("r3")).toHaveLength(0);
+    expect(blocks.get("r1")![0].leftPercent).toBe(blocks.get("r2")![0].leftPercent);
+    expect(blocks.get("r1")![0].widthPercent).toBe(blocks.get("r2")![0].widthPercent);
+  });
+
+  it("falls back to Primary facilityId when facilityIds is missing", () => {
+    expect(occupiedFacilityIds({ facilityId: "primary" })).toEqual(["primary"]);
+    expect(occupiedFacilityIds({ facilityIds: [], facilityId: "primary" })).toEqual(["primary"]);
+    expect(occupiedFacilityIds({ facilityIds: ["a", "b"], facilityId: "primary" })).toEqual(["a", "b"]);
+  });
+
+  it("omits cancelled bookings", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const roomId = "room-a";
+    const blocks = layoutGridOccupancyBlocks(
+      [
+        booking({
+          id: "cancelled",
+          facilityIds: [roomId],
+          status: "cancelled",
+          startAt: at(2026, 7, 20, 9, 0).toISOString(),
+          endAt: at(2026, 7, 20, 10, 0).toISOString(),
+        }),
+        booking({
+          id: "draft",
+          facilityIds: [roomId],
+          status: "draft",
+          startAt: at(2026, 7, 20, 11, 0).toISOString(),
+          endAt: at(2026, 7, 20, 12, 0).toISOString(),
+        }),
+      ],
+      [{ id: roomId }],
+      day
+    );
+    const roomBlocks = blocks.get(roomId) || [];
+    expect(roomBlocks.map((block) => block.booking.id)).toEqual(["draft"]);
+  });
+
+  it("stacks overlapping bookings on the same room into lanes", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const roomId = "room-a";
+    const blocks = layoutGridOccupancyBlocks(
+      [
+        booking({
+          id: "a",
+          facilityIds: [roomId],
+          startAt: at(2026, 7, 20, 9, 0).toISOString(),
+          endAt: at(2026, 7, 20, 11, 0).toISOString(),
+        }),
+        booking({
+          id: "b",
+          facilityIds: [roomId],
+          startAt: at(2026, 7, 20, 10, 0).toISOString(),
+          endAt: at(2026, 7, 20, 12, 0).toISOString(),
+        }),
+      ],
+      [{ id: roomId }],
+      day
+    );
+    const roomBlocks = blocks.get(roomId) || [];
+    expect(roomBlocks).toHaveLength(2);
+    expect(new Set(roomBlocks.map((block) => block.lane)).size).toBe(2);
+    expect(roomBlocks.every((block) => block.laneCount === 2)).toBe(true);
+  });
+
+  it("does not place bookings by facilityNames alone", () => {
+    const day = at(2026, 7, 20, 0, 0);
+    const blocks = layoutGridOccupancyBlocks(
+      [
+        booking({
+          id: "names-only",
+          facilityNames: ["Gym"],
+          startAt: at(2026, 7, 20, 9, 0).toISOString(),
+          endAt: at(2026, 7, 20, 10, 0).toISOString(),
+        }),
+      ],
+      [{ id: "gym-id" }],
+      day
+    );
+    expect(blocks.get("gym-id")).toEqual([]);
+  });
+});

--- a/src/pages/Facility/Booking/bookingGridLayout.ts
+++ b/src/pages/Facility/Booking/bookingGridLayout.ts
@@ -1,0 +1,157 @@
+import type { BookingListItem } from "@/api/services/facilityService";
+
+export const GRID_CELL_MINUTES = 30;
+export const GRID_DAY_MINUTES = 24 * 60;
+export const GRID_CELL_COUNT = GRID_DAY_MINUTES / GRID_CELL_MINUTES;
+export const DEFAULT_VIEWPORT_MINUTE = 8 * 60;
+
+export interface GridOccupancyBlock {
+  booking: BookingListItem;
+  leftPercent: number;
+  widthPercent: number;
+  startMinutes: number;
+  endMinutes: number;
+  lane: number;
+  laneCount: number;
+}
+
+export interface ClickInterval {
+  start: Date;
+  end: Date;
+}
+
+const startOfLocalDay = (date: Date): Date => {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+};
+
+const addMinutes = (date: Date, minutes: number): Date => {
+  const next = new Date(date);
+  next.setMinutes(next.getMinutes() + minutes);
+  return next;
+};
+
+export const formatGridHourLabel = (hour: number): string => {
+  if (hour === 24) return "12:00 AM";
+  const normalized = ((hour % 24) + 24) % 24;
+  const period = normalized < 12 ? "AM" : "PM";
+  const display = normalized % 12 === 0 ? 12 : normalized % 12;
+  return `${display}:00 ${period}`;
+};
+
+export const formatGridCellStartLabel = (cellIndex: number): string => {
+  const clamped = Math.max(0, Math.min(GRID_CELL_COUNT - 1, cellIndex));
+  const totalMinutes = clamped * GRID_CELL_MINUTES;
+  const hour24 = Math.floor(totalMinutes / 60);
+  const minute = totalMinutes % 60;
+  const period = hour24 < 12 ? "AM" : "PM";
+  const display = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return `${display}:${String(minute).padStart(2, "0")} ${period}`;
+};
+
+export const gridHourLabels = (): string[] => Array.from({ length: 25 }, (_, hour) => formatGridHourLabel(hour));
+
+export const clickIntervalForCell = (anchorDate: Date, cellIndex: number): ClickInterval => {
+  const clamped = Math.max(0, Math.min(GRID_CELL_COUNT - 1, cellIndex));
+  const dayStart = startOfLocalDay(anchorDate);
+  const start = addMinutes(dayStart, clamped * GRID_CELL_MINUTES);
+  const end = addMinutes(dayStart, (clamped + 1) * GRID_CELL_MINUTES);
+  return { start, end };
+};
+
+export const occupiedFacilityIds = (booking: Pick<BookingListItem, "facilityId" | "facilityIds">): string[] => {
+  if (booking.facilityIds && booking.facilityIds.length > 0) {
+    return booking.facilityIds;
+  }
+  if (booking.facilityId) {
+    return [booking.facilityId];
+  }
+  return [];
+};
+
+const assignOverlapLanes = (blocks: Omit<GridOccupancyBlock, "lane" | "laneCount">[]): GridOccupancyBlock[] => {
+  const sorted = [...blocks].sort((a, b) => a.startMinutes - b.startMinutes || a.endMinutes - b.endMinutes);
+  const laneEnds: number[] = [];
+  const withLanes = sorted.map((block) => {
+    let lane = laneEnds.findIndex((end) => end <= block.startMinutes);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(block.endMinutes);
+    } else {
+      laneEnds[lane] = block.endMinutes;
+    }
+    return { ...block, lane, laneCount: 1 };
+  });
+
+  for (let i = 0; i < withLanes.length; i++) {
+    let clusterEnd = withLanes[i].endMinutes;
+    let maxLane = withLanes[i].lane;
+    let j = i + 1;
+    while (j < withLanes.length && withLanes[j].startMinutes < clusterEnd) {
+      clusterEnd = Math.max(clusterEnd, withLanes[j].endMinutes);
+      maxLane = Math.max(maxLane, withLanes[j].lane);
+      j++;
+    }
+    const laneCount = maxLane + 1;
+    for (let k = i; k < j; k++) {
+      withLanes[k].laneCount = laneCount;
+    }
+    i = j - 1;
+  }
+
+  return withLanes;
+};
+
+const layoutBlocksForRoom = (bookings: BookingListItem[], roomId: string, day: Date): GridOccupancyBlock[] => {
+  const dayStart = startOfLocalDay(day);
+  const dayEnd = addMinutes(dayStart, GRID_DAY_MINUTES);
+
+  const placed = bookings
+    .filter((item) => item.status !== "cancelled")
+    .filter((item) => occupiedFacilityIds(item).includes(roomId))
+    .map((item) => {
+      const start = new Date(item.startAt);
+      const end = new Date(item.endAt);
+      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+      if (end <= dayStart || start >= dayEnd) return null;
+
+      const clampedStart = start < dayStart ? dayStart : start;
+      const clampedEnd = end > dayEnd ? dayEnd : end;
+      if (clampedEnd <= clampedStart) return null;
+
+      const startMinutes = Math.max(0, (clampedStart.getTime() - dayStart.getTime()) / 60000);
+      const endMinutes = Math.min(GRID_DAY_MINUTES, (clampedEnd.getTime() - dayStart.getTime()) / 60000);
+      if (endMinutes <= startMinutes) return null;
+
+      return {
+        booking: item,
+        leftPercent: (startMinutes / GRID_DAY_MINUTES) * 100,
+        widthPercent: ((endMinutes - startMinutes) / GRID_DAY_MINUTES) * 100,
+        startMinutes,
+        endMinutes,
+      };
+    })
+    .filter((item): item is Omit<GridOccupancyBlock, "lane" | "laneCount"> => item !== null);
+
+  return assignOverlapLanes(placed);
+};
+
+export const layoutGridOccupancyBlocks = (
+  bookings: BookingListItem[],
+  rooms: Array<{ id: string }>,
+  anchorDate: Date
+): Map<string, GridOccupancyBlock[]> => {
+  const map = new Map<string, GridOccupancyBlock[]>();
+  for (const room of rooms) {
+    map.set(room.id, layoutBlocksForRoom(bookings, room.id, anchorDate));
+  }
+  return map;
+};
+
+export const defaultViewportScrollRatio = (): number => DEFAULT_VIEWPORT_MINUTE / GRID_DAY_MINUTES;
+
+export const toLocalDatetimeValue = (date: Date): string => {
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};


### PR DESCRIPTION
## Summary

Turns admin Booking Grid into a full-day (00:00–24:00) freeze-pane occupancy map with 30-minute cells, continuous bars, `facilityIds` row placement, and contained horizontal scroll on the time axis only.

Closes #17

Depends on core-api admin list `facilityIds` (see linked core PR for #64).

## Type of change

- [x] Bug fix
- [x] New feature or API
- [x] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Pure layout seam: `bookingGridLayout.ts` (+ Vitest).
- ADR 0002; ADR 0001 Grid clause superseded for Grid only.
- Room column fixed; time track uses `w-0 flex-1` + AppLayout `min-w-0` so the page is not stretched horizontally.
- Hour labels are 12-hour AM/PM aligned to hour ticks (no header cell borders).

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm run test` (includes `bookingGridLayout.test.ts`)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge
- [ ] Prefer merging the core-api `facilityIds` PR first (or together)

Made with [Cursor](https://cursor.com)