### PR TITLE
ci: enforce legal git branch names (pre-push + PR check)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Reject pushes of illegally named topic branches.
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+CHECKER="${ROOT_DIR}/scripts/check-branch-name.sh"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Skip deletes (local sha all zeros)
+  if [[ "${local_sha}" =~ ^0+$ ]]; then
+    continue
+  fi
+
+  case "${local_ref}" in
+    refs/heads/*)
+      branch_name="${local_ref#refs/heads/}"
+      "${CHECKER}" "${branch_name}"
+      ;;
+    *)
+      # Tags and other refs are not checked
+      ;;
+  esac
+done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,8 +2,17 @@
 # Reject pushes of illegally named topic branches.
 set -euo pipefail
 
-ROOT_DIR="$(git rev-parse --show-toplevel)"
+ROOT_DIR="$(git rev-parse --show-toplevel </dev/null)"
 CHECKER="${ROOT_DIR}/scripts/check-branch-name.sh"
+
+check_ref() {
+  local ref="$1"
+  case "${ref}" in
+    refs/heads/*)
+      "${CHECKER}" "${ref#refs/heads/}"
+      ;;
+  esac
+}
 
 while read -r local_ref local_sha remote_ref remote_sha; do
   # Skip deletes (local sha all zeros)
@@ -11,13 +20,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     continue
   fi
 
-  case "${local_ref}" in
-    refs/heads/*)
-      branch_name="${local_ref#refs/heads/}"
-      "${CHECKER}" "${branch_name}"
-      ;;
-    *)
-      # Tags and other refs are not checked
-      ;;
-  esac
+  # `git push origin HEAD` sends local_ref as "HEAD", not refs/heads/<branch>.
+  # Always validate the remote branch name being updated; also validate a
+  # concrete local branch ref when present.
+  check_ref "${remote_ref}"
+  if [[ "${local_ref}" == refs/heads/* ]]; then
+    check_ref "${local_ref}"
+  fi
 done

--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,0 +1,18 @@
+name: Branch name
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  branch-name:
+    name: Branch name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate PR head branch name
+        run: |
+          chmod +x scripts/check-branch-name.sh
+          scripts/check-branch-name.sh "${{ github.head_ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This document helps AI agents quickly understand the **Newlife Portal** admin SP
 
 ```bash
 pnpm install              # requires NODE_AUTH_TOKEN (GitHub Packages)
+./scripts/install-git-hooks.sh   # once per clone
 pnpm run dev              # http://localhost:5173 (strictPort — fails if taken)
 pnpm run type-check       # tsc -b --noEmit (required in CI)
 pnpm run test             # vitest run
@@ -44,9 +45,14 @@ pnpm run lint             # eslint . (not required for agent checks)
 pnpm run build            # tsc -b && vite build
 pnpm run build:stg        # --mode staging
 pnpm run build:prod       # --mode production
+./scripts/check-branch-name.test.sh
 ```
 
-CI (`.github/workflows/ci.yml`) runs `pnpm install --frozen-lockfile` and **`pnpm run type-check` only** on PRs/pushes to `main` and `develop`. It does not run `test` or `lint`.
+CI (`.github/workflows/ci.yml`) runs `pnpm install --frozen-lockfile` and **`pnpm run type-check` only** on PRs/pushes to `main` and `develop`. It does not run `test` or `lint`. PRs also run `.github/workflows/branch-name.yml` (`Branch name` check).
+
+### Branch names
+
+Topic branches: `{type}/{issue-number}-{short-description}` (types: `feat` `fix` `hotfix` `refactor` `perf` `test` `docs` `chore` `build` `ci`). Exceptions: `release/x.y.z`, `spike/{short-description}`, plus `main` / `develop`. Local: `.githooks/pre-push` after install. Emergency: `git push --no-verify`. Consider marking `Branch name` required in GitHub branch protection.
 
 Copy `.env.example` → `.env.local` before running locally. Copy `.envrc.example` → `.envrc` (or export `NODE_AUTH_TOKEN`) so pnpm can install `@efcnewlife/newlife-ui`.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Important flags:
 
 ```bash
 pnpm install
+./scripts/install-git-hooks.sh   # once per clone; see AGENTS.md Branch names
 pnpm run dev
 ```
 

--- a/scripts/check-branch-name.sh
+++ b/scripts/check-branch-name.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Validate a git branch name against the org naming convention.
+# Usage: check-branch-name.sh <branch-name>
+set -euo pipefail
+
+branch="${1:-}"
+
+if [[ -z "${branch}" ]]; then
+  echo "Usage: $0 <branch-name>" >&2
+  exit 1
+fi
+
+slug='[a-z0-9]+(-[a-z0-9]+)*'
+topic_types='feat|fix|hotfix|refactor|perf|test|docs|chore|build|ci'
+
+if [[ "${branch}" =~ ^(main|develop)$ ]]; then
+  exit 0
+fi
+
+if [[ "${branch}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  exit 0
+fi
+
+if [[ "${branch}" =~ ^spike/${slug}$ ]]; then
+  exit 0
+fi
+
+if [[ "${branch}" =~ ^(${topic_types})/[0-9]+-${slug}$ ]]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+Invalid branch name: ${branch}
+
+Expected one of:
+  main
+  develop
+  release/<major>.<minor>.<patch>          e.g. release/1.4.0
+  spike/<short-description>                e.g. spike/explore-calendar
+  <type>/<issue-number>-<short-description> e.g. feat/69-enforce-branch-names
+
+Types: feat fix hotfix refactor perf test docs chore build ci
+Short description: lowercase a-z, 0-9, single hyphens only
+EOF
+exit 1

--- a/scripts/check-branch-name.test.sh
+++ b/scripts/check-branch-name.test.sh
@@ -12,19 +12,27 @@ assert_exit() {
   local expected_exit="$1"
   local branch="$2"
   local label="$3"
+  local expect_substring="${4:-}"
   set +e
   output="$("${CHECKER}" "${branch}" 2>&1)"
   actual_exit=$?
   set -e
-  if [[ "${actual_exit}" -eq "${expected_exit}" ]]; then
-    pass_count=$((pass_count + 1))
-  else
+  if [[ "${actual_exit}" -ne "${expected_exit}" ]]; then
     fail_count=$((fail_count + 1))
     echo "FAIL: ${label}"
     echo "  branch: ${branch}"
     echo "  expected exit ${expected_exit}, got ${actual_exit}"
     echo "  output: ${output}"
+    return
   fi
+  if [[ -n "${expect_substring}" && "${output}" != *"${expect_substring}"* ]]; then
+    fail_count=$((fail_count + 1))
+    echo "FAIL: ${label} (missing guidance text)"
+    echo "  expected substring: ${expect_substring}"
+    echo "  output: ${output}"
+    return
+  fi
+  pass_count=$((pass_count + 1))
 }
 
 assert_exit 0 "main" "allows main"
@@ -42,16 +50,16 @@ assert_exit 0 "ci/10-branch-check" "allows ci"
 assert_exit 0 "release/1.4.0" "allows release semver"
 assert_exit 0 "spike/explore-calendar" "allows spike without issue"
 
-assert_exit 1 "feat/add-booking-grid" "rejects feat without issue"
-assert_exit 1 "Feat/1-foo" "rejects uppercase type"
-assert_exit 1 "feat/1-Foo" "rejects uppercase slug"
-assert_exit 1 "feat/1-" "rejects empty slug"
-assert_exit 1 "feat/1-bad--" "rejects consecutive hyphens"
-assert_exit 1 "feat/1--bad" "rejects leading hyphen in slug segment"
-assert_exit 1 "release/1.4.0-rc.1" "rejects release pre-release"
-assert_exit 1 "spike/" "rejects empty spike slug"
-assert_exit 1 "random-branch" "rejects unstructured name"
-assert_exit 1 "feature/1-foo" "rejects unknown type"
+assert_exit 1 "feat/add-booking-grid" "rejects feat without issue" "Invalid branch name"
+assert_exit 1 "Feat/1-foo" "rejects uppercase type" "Expected one of"
+assert_exit 1 "feat/1-Foo" "rejects uppercase slug" "feat/69-enforce-branch-names"
+assert_exit 1 "feat/1-" "rejects empty slug" "Invalid branch name"
+assert_exit 1 "feat/1-bad--" "rejects consecutive hyphens" "Invalid branch name"
+assert_exit 1 "feat/1--bad" "rejects leading hyphen in slug segment" "Invalid branch name"
+assert_exit 1 "release/1.4.0-rc.1" "rejects release pre-release" "release/<major>.<minor>.<patch>"
+assert_exit 1 "spike/" "rejects empty spike slug" "Invalid branch name"
+assert_exit 1 "random-branch" "rejects unstructured name" "Invalid branch name"
+assert_exit 1 "feature/1-foo" "rejects unknown type" "Invalid branch name"
 
 if [[ "${fail_count}" -gt 0 ]]; then
   echo "${fail_count} failed, ${pass_count} passed"

--- a/scripts/check-branch-name.test.sh
+++ b/scripts/check-branch-name.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Black-box tests for scripts/check-branch-name.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="${ROOT_DIR}/scripts/check-branch-name.sh"
+
+pass_count=0
+fail_count=0
+
+assert_exit() {
+  local expected_exit="$1"
+  local branch="$2"
+  local label="$3"
+  set +e
+  output="$("${CHECKER}" "${branch}" 2>&1)"
+  actual_exit=$?
+  set -e
+  if [[ "${actual_exit}" -eq "${expected_exit}" ]]; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: ${label}"
+    echo "  branch: ${branch}"
+    echo "  expected exit ${expected_exit}, got ${actual_exit}"
+    echo "  output: ${output}"
+  fi
+}
+
+assert_exit 0 "main" "allows main"
+assert_exit 0 "develop" "allows develop"
+assert_exit 0 "feat/69-enforce-branch-names" "allows feat with issue"
+assert_exit 0 "fix/45-typo" "allows fix with issue"
+assert_exit 0 "hotfix/9-prod-crash" "allows hotfix"
+assert_exit 0 "refactor/1-cleanup" "allows refactor"
+assert_exit 0 "perf/2-speed-up" "allows perf"
+assert_exit 0 "test/3-add-coverage" "allows test"
+assert_exit 0 "docs/4-readme" "allows docs"
+assert_exit 0 "chore/7-deps" "allows chore"
+assert_exit 0 "build/8-tooling" "allows build"
+assert_exit 0 "ci/10-branch-check" "allows ci"
+assert_exit 0 "release/1.4.0" "allows release semver"
+assert_exit 0 "spike/explore-calendar" "allows spike without issue"
+
+assert_exit 1 "feat/add-booking-grid" "rejects feat without issue"
+assert_exit 1 "Feat/1-foo" "rejects uppercase type"
+assert_exit 1 "feat/1-Foo" "rejects uppercase slug"
+assert_exit 1 "feat/1-" "rejects empty slug"
+assert_exit 1 "feat/1-bad--" "rejects consecutive hyphens"
+assert_exit 1 "feat/1--bad" "rejects leading hyphen in slug segment"
+assert_exit 1 "release/1.4.0-rc.1" "rejects release pre-release"
+assert_exit 1 "spike/" "rejects empty spike slug"
+assert_exit 1 "random-branch" "rejects unstructured name"
+assert_exit 1 "feature/1-foo" "rejects unknown type"
+
+if [[ "${fail_count}" -gt 0 ]]; then
+  echo "${fail_count} failed, ${pass_count} passed"
+  exit 1
+fi
+
+echo "All ${pass_count} checks passed"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Point this clone at the repo's .githooks directory.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push scripts/check-branch-name.sh scripts/check-branch-name.test.sh scripts/install-git-hooks.sh
+
+echo "Installed git hooks (core.hooksPath=.githooks)"
+echo "Emergency bypass: git push --no-verify"


### PR DESCRIPTION
## Summary

Add a shared branch-name checker, local `pre-push` hook, and PR workflow so illegal topic branch names are rejected before they land on `main`. Closes #23.

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [x] Dependency or tooling

## Implementation notes

- Pattern: `{type}/{issue-number}-{short-description}` with `release/x.y.z` and `spike/{slug}` exceptions; `main`/`develop` allowed.
- `pre-push` validates the remote `refs/heads/*` name (covers `git push origin HEAD`).
- After clone: `./scripts/install-git-hooks.sh`. Emergency: `git push --no-verify`.

## Testing

- [x] `./scripts/check-branch-name.test.sh`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge