### PR TITLE
feat: Calendar date control (picker + Today)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,22 @@ _Avoid_: treating Primary as the only occupied room on Grid
 Which admin booking surface is active: `list`, `calendar`, or `grid` (URL/`view` state).
 _Avoid_: conflating Calendar packing with Grid occupancy
 
+**Calendar layout**:
+Which Calendar chrome is active inside Booking view mode `calendar`: `week`, `day`, or `month`. It is stored in the URL with the booking `date` (alongside `view=calendar`), not only in ephemeral component state.
+_Avoid_: treating Calendar layout as Booking view mode, conflating Month with Booking Grid, relying on refresh-loss local state as the source of truth for layout
+
+**Calendar month layout**:
+The month Calendar layout: left is a month grid of Calendar booking events; each visible line in a cell is a compact summary (single fixed-color dot, Booking start time, Booker). How many lines fit is measured from the cell's height (at least one line when the day has events); when more events exist than fit, a clickable "+ N more" selects that day as the Calendar anchor date without opening a remainder popover. Clicking a summary line opens that booking and sets the anchor to that day. Days from adjacent months in the visible grid are selectable and show summaries; choosing one sets the anchor (and the shown month follows). Selecting a day keeps Calendar layout `month` and sets the Calendar anchor date. Right is the same day time-axis of Calendar booking events as Day for that anchor date, including the same Calendar density overflow rule (`K = 10` → Booking view mode `grid` for that date). Toolbar prev/next steps by one month and preserves the day-of-month when possible.
+_Avoid_: month grid as date-only navigation with no in-cell summaries, a list panel instead of the day time-axis, treating in-cell lines as the full Day time-axis, lunar / non-booking decorations, status- or room-colored dots as the v1 rule, remainder popover for overflow, stepping Month prev/next by day or week, a divergent overflow K on the month right pane
+
+**Calendar date control**:
+The Calendar toolbar control that sets the Calendar anchor date via a date picker and includes a Today action to jump to the current calendar day. It replaces a Today-only button and applies to every Calendar layout (`week`, `day`, `month`).
+_Avoid_: a separate Today button beside an independent date picker, treating this control as a Booking view mode switch, Calendar-only Today while Month uses a different jump control
+
+**Booking range query**:
+The non-paginated read used by Calendar and Booking Grid: given a required visible time window (`dateFrom` / `dateTo`), return every booking whose interval overlaps that window (`start < windowEnd` and `end > windowStart`). Cancelled bookings are excluded by default and may be included via an explicit query flag. The window length is capped (admin UI ranges fit within about two months). It is not the List DataTable `pages` query.
+_Avoid_: `getBookingPages` with a large `page_size` as the Calendar/Grid contract, filtering only by `start_at` inside the window, treating List pagination as occupancy completeness, requiring cancelled rows for the default occupancy surfaces
+
 **DataTable**:
 The Portal admin list shell built on `@efcnewlife/newlife-ui` Table primitives, plus pagination, sorting, row selection, and context menu. It is a host composite, not the library Table itself.
 _Avoid_: Table (when meaning the Portal list page), DataGrid, Grid

--- a/docs/adr/0001-calendar-concurrent-booking-lanes.md
+++ b/docs/adr/0001-calendar-concurrent-booking-lanes.md
@@ -22,7 +22,7 @@ Lay out overlapping Calendar booking events as a right-aligned card stack: the e
 - Visible lanes are the first K from greedy packing. Events assigned column index `>= K` are omitted. Overflow layout still uses each visible event's real `col` for indent (not `col / n`).
 - Calendar density overflow is a control on that overflowing group. Its label includes N (undrawn count). Activating it switches Booking view mode to `grid` and sets `date` to that day column's ISO date. It does not open detail, a context menu, or a remainder list.
 - One Calendar booking event per booking id; title is the Booker. Cancelled bookings stay off Calendar. Midnight-spanning bookings continue across day columns, with packing computed per day.
-- Month view is unused by booking Calendar and stays as-is. List view is unchanged. Booking Grid layout is governed by ADR 0002 (this ADR’s former “Grid unchanged” clause is superseded for Grid only).
+- Calendar month layout and Calendar date control are governed by ADR 0006 (this ADR’s former “Month view is unused” clause is superseded for Month only). List view is unchanged. Booking Grid layout is governed by ADR 0002 (this ADR’s former “Grid unchanged” clause is superseded for Grid only). Day and Week lane packing, K, and density overflow in this ADR still apply; Month’s right pane reuses Day’s rules (`K = 10`).
 
 ## Consequences
 

--- a/docs/adr/0006-calendar-month-layout-and-date-control.md
+++ b/docs/adr/0006-calendar-month-layout-and-date-control.md
@@ -1,0 +1,26 @@
+# 0006. Calendar month layout and date control
+
+## Status
+
+Accepted
+
+## Context
+
+Booking Calendar only offered week and day. Operators needed a month overview without losing the selected day's time-axis detail. The toolbar Today control could only jump to the current calendar day, not pick an arbitrary Calendar anchor date. Reusing the classic full-bleed month grid (events only in cells) would fight Day's time-axis and ADR 0001's density overflow story. Keeping Calendar layout only in component state meant refresh lost week/day/month.
+
+## Decision
+
+Add Calendar layout `month` beside `week` and `day`, and replace the Today-only control with a Calendar date control.
+
+- **Split pane:** Left is the month grid; right is the same day time-axis of Calendar booking events as Day for the Calendar anchor date (lane packing and Calendar density overflow with `K = 10` → Booking view mode `grid` for that date).
+- **In-cell summary:** Each visible line is a compact summary: single fixed-color dot, Booking start time, Booker. Line count is measured from cell height (at least one line when the day has events). Clickable `+ N more` selects that day as anchor; it does not open a remainder popover. Clicking a summary opens that booking and sets the anchor. Selecting a day keeps layout `month`.
+- **Adjacent-month padding days** in the visible grid are selectable and show summaries; choosing one sets the anchor (shown month follows).
+- **Toolbar:** In month, prev/next steps by one month and preserves day-of-month when possible. Calendar date control (date picker + Today action) sets the Calendar anchor date for every Calendar layout (`week`, `day`, `month`). Day's existing right-hand mini month stays for now.
+- **URL:** With `view=calendar`, persist Calendar layout (e.g. `layout=month`) alongside `date`.
+- **Data:** Calendar (and Grid) load via the core-api Booking range query (core ADR 0007), not List `pages`. Delivery is phased: range query + wire Calendar/Grid first; then Month UI and date control.
+
+## Consequences
+
+- Month is a navigation-plus-preview surface; Day remains the primary dense day chrome; Grid remains the overflow occupancy map.
+- ADR 0001 still owns week/day lane packing; this ADR owns Month chrome and the date control.
+- Do not restore Today-only toolbar jump, remainder popovers for cell overflow, status/room-colored dots as the v1 Month rule, or Calendar layout that exists only in ephemeral component state without superseding this ADR.

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -21,6 +21,10 @@ const Calendar = ({
 }: CalendarProps) => {
   const [selectedDate, setSelectedDate] = useState<Date>(currentDate);
 
+  useEffect(() => {
+    setSelectedDate(currentDate);
+  }, [currentDate]);
+
   // Validate and set initial view
   const getInitialView = (): CalendarView => {
     if (availableViews.includes(defaultView)) {
@@ -33,27 +37,27 @@ const Calendar = ({
   const [currentView, setCurrentView] = useState<CalendarView>(getInitialView());
 
   // Get showNavigationButtons value based on current view
-  const getShowNavigationButtons = (): { nav: boolean; today: boolean } => {
+  const getShowNavigationButtons = (): { nav: boolean; dateControl: boolean } => {
     if (typeof showNavigationButtons === "boolean") {
-      return { nav: showNavigationButtons, today: showNavigationButtons };
+      return { nav: showNavigationButtons, dateControl: showNavigationButtons };
     }
 
     // If it's an object, get the value for current view
     const viewConfig = showNavigationButtons[currentView];
 
     if (viewConfig === undefined) {
-      return { nav: false, today: false };
+      return { nav: false, dateControl: false };
     }
 
-    // If it's a boolean, use it for both nav and today
+    // If it's a boolean, use it for both nav and date control
     if (typeof viewConfig === "boolean") {
-      return { nav: viewConfig, today: viewConfig };
+      return { nav: viewConfig, dateControl: viewConfig };
     }
 
-    // If it's an object with nav and today properties
+    // If it's an object with nav and dateControl properties
     return {
       nav: viewConfig.nav ?? false,
-      today: viewConfig.today ?? false,
+      dateControl: viewConfig.dateControl ?? false,
     };
   };
 
@@ -109,10 +113,6 @@ const Calendar = ({
     handleDateChange(newDate);
   };
 
-  const handleToday = () => {
-    handleDateChange(new Date());
-  };
-
   const renderView = () => {
     const viewProps = {
       currentDate: selectedDate,
@@ -144,7 +144,7 @@ const Calendar = ({
         validRange={validRange}
         onPrevious={handlePrevious}
         onNext={handleNext}
-        onToday={handleToday}
+        onDateChange={handleDateChange}
         onViewChange={handleViewChange}
         onAddEvent={onAddEvent ? () => onAddEvent() : undefined}
         showNavigationButtons={getShowNavigationButtons()}

--- a/src/components/calendar/CalendarDateControl.tsx
+++ b/src/components/calendar/CalendarDateControl.tsx
@@ -1,0 +1,50 @@
+import { DatePicker } from "@efcnewlife/newlife-ui";
+import { useTranslation } from "react-i18next";
+import { usePickerLabels } from "@/hooks/usePickerLabels";
+import { dateToCalendarDateControlValue, dayjsToCalendarAnchorDate } from "./calendarAnchorDate";
+import type { DateRange } from "./types";
+
+interface CalendarDateControlProps {
+  id?: string;
+  value: Date;
+  onChange: (date: Date) => void;
+  validRange?: DateRange;
+  className?: string;
+}
+
+const CalendarDateControl = ({
+  id = "calendar-date-control",
+  value,
+  onChange,
+  validRange,
+  className,
+}: CalendarDateControlProps) => {
+  const { t } = useTranslation("calendar");
+  const pickerLabels = usePickerLabels();
+
+  return (
+    <DatePicker
+      id={id}
+      value={dateToCalendarDateControlValue(value)}
+      onChange={(next) => {
+        const date = dayjsToCalendarAnchorDate(next);
+        if (date) {
+          onChange(date);
+        }
+      }}
+      minDate={validRange?.start}
+      maxDate={validRange?.end}
+      clearable={false}
+      showTodayButton
+      size="sm"
+      className={className}
+      wrapperClassName="mb-0"
+      labels={{
+        ...pickerLabels,
+        today: t("today"),
+      }}
+    />
+  );
+};
+
+export default CalendarDateControl;

--- a/src/components/calendar/CalendarDateControl.tsx
+++ b/src/components/calendar/CalendarDateControl.tsx
@@ -1,49 +1,96 @@
-import { DatePicker } from "@efcnewlife/newlife-ui";
-import { useTranslation } from "react-i18next";
 import { usePickerLabels } from "@/hooks/usePickerLabels";
+import { cn } from "@/utils";
+import { DateCalendar } from "@efcnewlife/newlife-ui";
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { MdCalendarMonth } from "react-icons/md";
 import { dateToCalendarDateControlValue, dayjsToCalendarAnchorDate } from "./calendarAnchorDate";
 import type { DateRange } from "./types";
 
 interface CalendarDateControlProps {
-  id?: string;
   value: Date;
   onChange: (date: Date) => void;
   validRange?: DateRange;
-  className?: string;
+  /** Classes for the icon trigger (nav segment styling). */
+  triggerClassName?: string;
 }
 
-const CalendarDateControl = ({
-  id = "calendar-date-control",
-  value,
-  onChange,
-  validRange,
-  className,
-}: CalendarDateControlProps) => {
+const CalendarDateControl = ({ value, onChange, validRange, triggerClassName }: CalendarDateControlProps) => {
   const { t } = useTranslation("calendar");
   const pickerLabels = usePickerLabels();
+  const labelId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
 
   return (
-    <DatePicker
-      id={id}
-      value={dateToCalendarDateControlValue(value)}
-      onChange={(next) => {
-        const date = dayjsToCalendarAnchorDate(next);
-        if (date) {
-          onChange(date);
-        }
-      }}
-      minDate={validRange?.start}
-      maxDate={validRange?.end}
-      clearable={false}
-      showTodayButton
-      size="sm"
-      className={className}
-      wrapperClassName="mb-0"
-      labels={{
-        ...pickerLabels,
-        today: t("today"),
-      }}
-    />
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-labelledby={labelId}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((current) => !current)}
+        className={cn(
+          "flex h-9 w-9 items-center justify-center text-gray-500 hover:bg-gray-50 hover:text-gray-700 focus:relative dark:text-gray-300 dark:hover:bg-white/10 dark:hover:text-white",
+          triggerClassName
+        )}
+      >
+        <span id={labelId} className="sr-only">
+          {t("dateControl.open")}
+        </span>
+        <MdCalendarMonth className="size-5" />
+      </button>
+      {open ? (
+        <div
+          className="absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2"
+          role="dialog"
+          aria-label={t("dateControl.open")}
+        >
+          <DateCalendar
+            value={dateToCalendarDateControlValue(value)}
+            onChange={(next) => {
+              const date = dayjsToCalendarAnchorDate(next);
+              if (date) {
+                onChange(date);
+                setOpen(false);
+              }
+            }}
+            minDate={validRange?.start}
+            maxDate={validRange?.end}
+            showTodayButton
+            labels={{
+              ...pickerLabels,
+              today: t("today"),
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
   );
 };
 

--- a/src/components/calendar/CalendarToolbar.tsx
+++ b/src/components/calendar/CalendarToolbar.tsx
@@ -1,5 +1,6 @@
 import { Badge, Button, ButtonGroup } from "@efcnewlife/newlife-ui";
 import { useTranslation } from "react-i18next";
+import { cn } from "@/utils";
 import NavigationButtons from "./NavigationButtons";
 import { CalendarView, DateRange } from "./types";
 import { formatDate, formatWeekday, getEndOfWeek, getStartOfWeek } from "./utils";
@@ -11,10 +12,10 @@ interface CalendarToolBarProps {
   validRange?: DateRange;
   onPrevious: () => void;
   onNext: () => void;
-  onToday: () => void;
+  onDateChange: (date: Date) => void;
   onViewChange: (view: CalendarView) => void;
   onAddEvent?: () => void;
-  showNavigationButtons?: { nav: boolean; today: boolean };
+  showNavigationButtons?: { nav: boolean; dateControl: boolean };
 }
 
 const CalendarToolBar = ({
@@ -24,10 +25,10 @@ const CalendarToolBar = ({
   validRange,
   onPrevious,
   onNext,
-  onToday,
+  onDateChange,
   onViewChange,
   onAddEvent,
-  showNavigationButtons = { nav: true, today: true },
+  showNavigationButtons = { nav: true, dateControl: true },
 }: CalendarToolBarProps) => {
   const { t, i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
@@ -211,19 +212,24 @@ const CalendarToolBar = ({
         </div>
       </div>
       <div className="flex items-center">
-        {(showNavigationButtons.nav || showNavigationButtons.today) && (
+        {(showNavigationButtons.nav || showNavigationButtons.dateControl) && (
           <NavigationButtons
             currentDate={currentDate}
             currentView={currentView}
             validRange={validRange}
             onPrevious={onPrevious}
             onNext={onNext}
-            onToday={onToday}
+            onDateChange={onDateChange}
             showNav={showNavigationButtons.nav}
-            showToday={showNavigationButtons.today}
+            showDateControl={showNavigationButtons.dateControl}
           />
         )}
-        <div className={`flex items-center ${showNavigationButtons.nav || showNavigationButtons.today ? "ml-4" : ""}`}>
+        <div
+          className={cn(
+            "flex items-center",
+            (showNavigationButtons.nav || showNavigationButtons.dateControl) && "ml-4"
+          )}
+        >
           {availableViews.length > 1 && (
             <div className="mr-4">
               <ButtonGroup

--- a/src/components/calendar/NavigationButtons.tsx
+++ b/src/components/calendar/NavigationButtons.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@efcnewlife/newlife-ui";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { useTranslation } from "react-i18next";
+import { cn } from "@/utils";
+import CalendarDateControl from "./CalendarDateControl";
 import { CalendarView, DateRange } from "./types";
 import { canNavigateNext, canNavigatePrevious } from "./utils";
 
@@ -10,9 +11,10 @@ interface NavigationButtonsProps {
   validRange?: DateRange;
   onPrevious: () => void;
   onNext: () => void;
-  onToday: () => void;
+  onDateChange: (date: Date) => void;
   showNav?: boolean;
-  showToday?: boolean;
+  /** When true, show the Calendar date control (date picker + Today). */
+  showDateControl?: boolean;
 }
 
 const NavigationButtons = ({
@@ -21,13 +23,12 @@ const NavigationButtons = ({
   validRange,
   onPrevious,
   onNext,
-  onToday,
+  onDateChange,
   showNav = true,
-  showToday = true,
+  showDateControl = true,
 }: NavigationButtonsProps) => {
   const { t } = useTranslation("calendar");
   const showPreviousNext = showNav;
-  const showTodayButton = showToday;
 
   const getPreviousLabel = (view: CalendarView): string => {
     switch (view) {
@@ -51,73 +52,39 @@ const NavigationButtons = ({
     }
   };
 
-  // If neither nav nor today should be shown, return null
-  if (!showPreviousNext && !showTodayButton) {
+  if (!showPreviousNext && !showDateControl) {
     return null;
   }
 
-  // Determine rounded corners based on which buttons are shown
-  const getPreviousClasses = () => {
-    const baseClasses =
-      "flex h-9 w-9 items-center justify-center text-gray-400 hover:text-gray-500 focus:relative hover:bg-gray-50 dark:hover:text-white dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-gray-400 disabled:hover:bg-transparent";
-    if (!showTodayButton) {
-      // Only nav buttons: Previous has left rounded, Next has right rounded
-      return `${baseClasses} rounded-l-md`;
-    }
-    // Both nav and today: Previous has left rounded only
-    return `${baseClasses} rounded-l-md`;
-  };
-
-  const getTodayClasses = () => {
-    const baseClasses =
-      "h-9 px-3.5 py-2 text-sm font-semibold border-0 shadow-none bg-transparent hover:bg-gray-50 dark:hover:bg-white/10";
-    if (!showPreviousNext) {
-      // Only today button: has both rounded corners
-      return `${baseClasses} rounded-md`;
-    }
-    // Both nav and today: no rounded corners
-    return `${baseClasses} rounded-none`;
-  };
-
-  const getNextClasses = () => {
-    const baseClasses =
-      "flex h-9 w-9 items-center justify-center text-gray-400 hover:text-gray-500 focus:relative hover:bg-gray-50 dark:hover:text-white dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-gray-400 disabled:hover:bg-transparent";
-    if (!showTodayButton) {
-      // Only nav buttons: Next has right rounded
-      return `${baseClasses} rounded-r-md`;
-    }
-    // Both nav and today: Next has right rounded only
-    return `${baseClasses} rounded-r-md`;
-  };
+  const navButtonClasses =
+    "flex h-9 w-9 items-center justify-center text-gray-400 hover:text-gray-500 focus:relative hover:bg-gray-50 dark:hover:text-white dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-gray-400 disabled:hover:bg-transparent";
 
   return (
-    <div className="relative flex items-stretch rounded-md bg-white shadow-xs outline -outline-offset-1 outline-gray-300 dark:bg-white/10 dark:shadow-none dark:outline-white/5">
+    <div className="flex items-center gap-2">
       {showPreviousNext && (
-        <button
-          type="button"
-          onClick={onPrevious}
-          disabled={!canNavigatePrevious(currentDate, currentView, validRange)}
-          className={getPreviousClasses()}
-        >
-          <span className="sr-only">{getPreviousLabel(currentView)}</span>
-          <MdChevronLeft className="size-5" />
-        </button>
+        <div className="relative flex items-stretch rounded-md bg-white shadow-xs outline -outline-offset-1 outline-gray-300 dark:bg-white/10 dark:shadow-none dark:outline-white/5">
+          <button
+            type="button"
+            onClick={onPrevious}
+            disabled={!canNavigatePrevious(currentDate, currentView, validRange)}
+            className={cn(navButtonClasses, "rounded-l-md")}
+          >
+            <span className="sr-only">{getPreviousLabel(currentView)}</span>
+            <MdChevronLeft className="size-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            disabled={!canNavigateNext(currentDate, currentView, validRange)}
+            className={cn(navButtonClasses, "rounded-r-md")}
+          >
+            <span className="sr-only">{getNextLabel(currentView)}</span>
+            <MdChevronRight className="size-5" />
+          </button>
+        </div>
       )}
-      {showTodayButton && (
-        <Button onClick={onToday} variant="outline" size="sm" className={getTodayClasses()}>
-          {t("today")}
-        </Button>
-      )}
-      {showPreviousNext && (
-        <button
-          type="button"
-          onClick={onNext}
-          disabled={!canNavigateNext(currentDate, currentView, validRange)}
-          className={getNextClasses()}
-        >
-          <span className="sr-only">{getNextLabel(currentView)}</span>
-          <MdChevronRight className="size-5" />
-        </button>
+      {showDateControl && (
+        <CalendarDateControl value={currentDate} onChange={onDateChange} validRange={validRange} />
       )}
     </div>
   );

--- a/src/components/calendar/NavigationButtons.tsx
+++ b/src/components/calendar/NavigationButtons.tsx
@@ -1,6 +1,6 @@
-import { MdChevronLeft, MdChevronRight } from "react-icons/md";
-import { useTranslation } from "react-i18next";
 import { cn } from "@/utils";
+import { useTranslation } from "react-i18next";
+import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import CalendarDateControl from "./CalendarDateControl";
 import { CalendarView, DateRange } from "./types";
 import { canNavigateNext, canNavigatePrevious } from "./utils";
@@ -59,32 +59,42 @@ const NavigationButtons = ({
   const navButtonClasses =
     "flex h-9 w-9 items-center justify-center text-gray-400 hover:text-gray-500 focus:relative hover:bg-gray-50 dark:hover:text-white dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-gray-400 disabled:hover:bg-transparent";
 
+  const dateControlTriggerClassName = cn(
+    !showPreviousNext && "rounded-md",
+    showPreviousNext && "rounded-none border-x border-gray-200 dark:border-white/10"
+  );
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="relative flex items-stretch rounded-md bg-white shadow-xs outline -outline-offset-1 outline-gray-300 dark:bg-white/10 dark:shadow-none dark:outline-white/5">
       {showPreviousNext && (
-        <div className="relative flex items-stretch rounded-md bg-white shadow-xs outline -outline-offset-1 outline-gray-300 dark:bg-white/10 dark:shadow-none dark:outline-white/5">
-          <button
-            type="button"
-            onClick={onPrevious}
-            disabled={!canNavigatePrevious(currentDate, currentView, validRange)}
-            className={cn(navButtonClasses, "rounded-l-md")}
-          >
-            <span className="sr-only">{getPreviousLabel(currentView)}</span>
-            <MdChevronLeft className="size-5" />
-          </button>
-          <button
-            type="button"
-            onClick={onNext}
-            disabled={!canNavigateNext(currentDate, currentView, validRange)}
-            className={cn(navButtonClasses, "rounded-r-md")}
-          >
-            <span className="sr-only">{getNextLabel(currentView)}</span>
-            <MdChevronRight className="size-5" />
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={onPrevious}
+          disabled={!canNavigatePrevious(currentDate, currentView, validRange)}
+          className={cn(navButtonClasses, "rounded-l-md")}
+        >
+          <span className="sr-only">{getPreviousLabel(currentView)}</span>
+          <MdChevronLeft className="size-5" />
+        </button>
       )}
       {showDateControl && (
-        <CalendarDateControl value={currentDate} onChange={onDateChange} validRange={validRange} />
+        <CalendarDateControl
+          value={currentDate}
+          onChange={onDateChange}
+          validRange={validRange}
+          triggerClassName={dateControlTriggerClassName}
+        />
+      )}
+      {showPreviousNext && (
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={!canNavigateNext(currentDate, currentView, validRange)}
+          className={cn(navButtonClasses, "rounded-r-md")}
+        >
+          <span className="sr-only">{getNextLabel(currentView)}</span>
+          <MdChevronRight className="size-5" />
+        </button>
       )}
     </div>
   );

--- a/src/components/calendar/calendarAnchorDate.test.ts
+++ b/src/components/calendar/calendarAnchorDate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import dayjs from "@/utils/dayjsSetup";
+import { dateToCalendarDateControlValue, dayjsToCalendarAnchorDate } from "./calendarAnchorDate";
+
+describe("dateToCalendarDateControlValue", () => {
+  it("normalizes the Calendar anchor Date to local start of day", () => {
+    const value = dateToCalendarDateControlValue(new Date(2026, 7, 21, 15, 45, 30));
+    expect(value.format("YYYY-MM-DD HH:mm:ss")).toBe("2026-08-21 00:00:00");
+  });
+});
+
+describe("dayjsToCalendarAnchorDate", () => {
+  it("returns a local midnight Date for a valid Dayjs value", () => {
+    const date = dayjsToCalendarAnchorDate(dayjs("2026-08-21 15:45:30"));
+    expect(date).not.toBeNull();
+    expect(date!.getFullYear()).toBe(2026);
+    expect(date!.getMonth()).toBe(7);
+    expect(date!.getDate()).toBe(21);
+    expect(date!.getHours()).toBe(0);
+    expect(date!.getMinutes()).toBe(0);
+    expect(date!.getSeconds()).toBe(0);
+  });
+
+  it("returns null for null or invalid Dayjs values", () => {
+    expect(dayjsToCalendarAnchorDate(null)).toBeNull();
+    expect(dayjsToCalendarAnchorDate(dayjs("not-a-date"))).toBeNull();
+  });
+});

--- a/src/components/calendar/calendarAnchorDate.test.ts
+++ b/src/components/calendar/calendarAnchorDate.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import dayjs from "@/utils/dayjsSetup";
+import { describe, expect, it } from "vitest";
 import { dateToCalendarDateControlValue, dayjsToCalendarAnchorDate } from "./calendarAnchorDate";
 
 describe("dateToCalendarDateControlValue", () => {

--- a/src/components/calendar/calendarAnchorDate.ts
+++ b/src/components/calendar/calendarAnchorDate.ts
@@ -1,0 +1,19 @@
+import dayjs, { type Dayjs } from "@/utils/dayjsSetup";
+
+/** Convert a Calendar anchor Date to a Dayjs value for the Calendar date control. */
+export const dateToCalendarDateControlValue = (date: Date): Dayjs => {
+  return dayjs(date).startOf("day");
+};
+
+/**
+ * Convert a Calendar date control Dayjs value to a local midnight Date.
+ * Returns null when the value is missing or invalid (clear is not used for anchors).
+ */
+export const dayjsToCalendarAnchorDate = (value: Dayjs | null): Date | null => {
+  if (value == null || !value.isValid()) {
+    return null;
+  }
+  const next = value.toDate();
+  next.setHours(0, 0, 0, 0);
+  return next;
+};

--- a/src/components/calendar/types.ts
+++ b/src/components/calendar/types.ts
@@ -53,10 +53,10 @@ export interface CalendarProps {
   showNavigationButtons?:
     | boolean
     | {
-        month?: boolean | { nav?: boolean; today?: boolean };
-        week?: boolean | { nav?: boolean; today?: boolean };
-        day?: boolean | { nav?: boolean; today?: boolean };
-      }; // Whether to display switching period and Today button, which can be a boolean or an object configured according to the view
+        month?: boolean | { nav?: boolean; dateControl?: boolean };
+        week?: boolean | { nav?: boolean; dateControl?: boolean };
+        day?: boolean | { nav?: boolean; dateControl?: boolean };
+      }; // Whether to display prev/next and the Calendar date control, by view
 }
 
 export interface CalendarViewProps {

--- a/src/i18n/locales/en/calendar.json
+++ b/src/i18n/locales/en/calendar.json
@@ -5,6 +5,9 @@
     "month": "Month"
   },
   "today": "Today",
+  "dateControl": {
+    "open": "Go to date"
+  },
   "weekOfMonth": "Week {{week}}",
   "addBooking": "Add booking",
   "densityOverflow": "{{count}} more — view in Grid",

--- a/src/i18n/locales/zh-CN/calendar.json
+++ b/src/i18n/locales/zh-CN/calendar.json
@@ -5,6 +5,9 @@
     "month": "月"
   },
   "today": "今天",
+  "dateControl": {
+    "open": "前往日期"
+  },
   "weekOfMonth": "第 {{week}} 周",
   "addBooking": "新增预约",
   "densityOverflow": "另有 {{count}} 笔，改以 Grid 查看",

--- a/src/i18n/locales/zh-TW/calendar.json
+++ b/src/i18n/locales/zh-TW/calendar.json
@@ -5,6 +5,9 @@
     "month": "月"
   },
   "today": "今天",
+  "dateControl": {
+    "open": "前往日期"
+  },
   "weekOfMonth": "第 {{week}} 週",
   "addBooking": "新增預約",
   "densityOverflow": "另有 {{count}} 筆，改以 Grid 檢視",

--- a/src/pages/Facility/Booking/BookingGrid.tsx
+++ b/src/pages/Facility/Booking/BookingGrid.tsx
@@ -135,7 +135,7 @@ const BookingGrid = ({
           currentView="day"
           onPrevious={() => shiftDay(-1)}
           onNext={() => shiftDay(1)}
-          onToday={() => onAnchorDateChange(new Date())}
+          onDateChange={onAnchorDateChange}
         />
       </div>
 


### PR DESCRIPTION
## Summary

Replace the Calendar toolbar Today-only button with a single **Calendar date control**: a compact calendar-icon trigger nested between prev/next that opens a date picker with a Today action. Anchor date text stays on the left toolbar to avoid duplication. Closes #31.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Control is shared via `NavigationButtons` across Calendar layouts (`week` / `day`; reusable for `month`) and Booking Grid chrome.
- Day view’s right-hand mini month is unchanged.
- ADR 0006 + CONTEXT glossary for Calendar date control / related layout terms; ADR 0001 points Month + date control to ADR 0006.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] `pnpm run format:check` (CI)

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge