### PR TITLE
fix: restore Booking Calendar Day/Week vertical scroll

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -136,7 +136,7 @@ const Calendar = ({
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <CalendarToolBar
         currentDate={selectedDate}
         currentView={currentView}

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -147,9 +147,9 @@ const DayView = ({
   };
 
   return (
-    <div className="flex flex-auto overflow-hidden border border-gray-300 dark:border-white/10 rounded-b-2xl">
-      <div className="flex flex-1 flex-col overflow-auto">
-        <div className="relative flex flex-1 overflow-y-auto">
+    <div className="flex min-h-0 flex-1 overflow-hidden border border-gray-300 dark:border-white/10 rounded-b-2xl">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="relative flex min-h-0 flex-1 overflow-y-auto">
           {/* Left time axis */}
           <div className="flex h-max w-18 flex-col border-r border-gray-300 dark:border-white/10 bg-gray-50 dark:bg-gray-800/50">
             {hours.map((hour) => (

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -117,9 +117,9 @@ const WeekView = ({
   };
 
   return (
-    <div className="flex flex-1 flex-col overflow-auto max-md:hidden border border-gray-300 dark:border-white/10 rounded-b-2xl">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden max-md:hidden border border-gray-300 dark:border-white/10 rounded-b-2xl">
       {/* Header with weekday labels */}
-      <div className="sticky top-0 grid grid-cols-7 bg-white dark:bg-gray-900 pl-18 shadow-sm border-b border-gray-300 dark:border-white/10">
+      <div className="grid shrink-0 grid-cols-7 bg-white dark:bg-gray-900 pl-18 shadow-sm border-b border-gray-300 dark:border-white/10">
         {weekDates.map((date, index) => {
           const today = new Date();
           today.setHours(0, 0, 0, 0);
@@ -164,7 +164,7 @@ const WeekView = ({
         })}
       </div>
 
-      <div className="relative flex flex-1 overflow-y-auto">
+      <div className="relative flex min-h-0 flex-1 overflow-y-auto">
         {/* Left time axis */}
         <div className="flex h-max w-18 flex-col border-r border-gray-300 dark:border-white/10 bg-gray-50 dark:bg-gray-800/50">
           {hours.map((hour) => (

--- a/src/pages/Facility/Booking/BookingCalendar.tsx
+++ b/src/pages/Facility/Booking/BookingCalendar.tsx
@@ -100,7 +100,7 @@ const BookingCalendar = ({
   );
 
   return (
-    <div className="relative">
+    <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
       <Calendar
         currentDate={anchorDate}
         defaultView="week"

--- a/src/pages/Facility/Booking/BookingDataPage.tsx
+++ b/src/pages/Facility/Booking/BookingDataPage.tsx
@@ -350,7 +350,7 @@ const BookingDataPage = () => {
       )}
 
       {viewMode === "calendar" && (
-        <div className="min-h-0 flex-1 space-y-3">
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
           <BookingCalendar
             anchorDate={anchorDate}
             bookings={calendarItems}


### PR DESCRIPTION
## Summary

Booking Calendar View (Day and Week) clipped the time grid and ignored vertical scroll because the Calendar flex/overflow height chain was incomplete. This aligns the Calendar wrappers with the Grid pattern so the day axis scrolls inside a bounded pane.

Closes #29

## Type of change

- [x] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Calendar branch now uses `min-h-0` / `overflow-hidden` (and height forwarding) like Grid.
- Week weekday header uses `shrink-0` above the scrolling body (same pinned-header meaning without sticky-on-outer-scroll).
- Lane packing and Month view intentionally unchanged.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm run test`
- [ ] Manual: Calendar Day/Week vertical scroll; Grid scroll unchanged

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)