### PR TITLE
feat: wire Calendar and Grid to Booking range query

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -187,6 +187,7 @@ export const API_ENDPOINTS = {
     },
     BOOKINGS: {
       PAGES: `${ADMIN_API_PREFIX}/facility/bookings/pages`,
+      RANGE: `${ADMIN_API_PREFIX}/facility/bookings/range`,
       CREATE: `${ADMIN_API_PREFIX}/facility/bookings`,
       DETAIL: (id: string) => `${ADMIN_API_PREFIX}/facility/bookings/${id}`,
       UPDATE: (id: string) => `${ADMIN_API_PREFIX}/facility/bookings/${id}`,

--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -313,6 +313,12 @@ export interface BookingPagesParams extends PagesParams {
   dateTo?: string;
 }
 
+export interface BookingRangeParams {
+  dateFrom: string;
+  dateTo: string;
+  includeCancelled?: boolean;
+}
+
 export interface BookingListItem {
   id: string;
   userId: string;
@@ -729,6 +735,18 @@ class FacilityService {
   async getBookingPages(params: BookingPagesParams): Promise<ApiResponse<PagesResponse<BookingListItem>>> {
     if (IS_MOCK_API) return emptyPages();
     return httpClient.get(API_ENDPOINTS.FACILITY.BOOKINGS.PAGES, params as Record<string, unknown>);
+  }
+
+  async getBookingRange(params: BookingRangeParams): Promise<ApiResponse<{ items: BookingListItem[] }>> {
+    if (IS_MOCK_API) return emptyList();
+    const query: Record<string, unknown> = {
+      dateFrom: params.dateFrom,
+      dateTo: params.dateTo,
+    };
+    if (params.includeCancelled !== undefined) {
+      query.includeCancelled = params.includeCancelled;
+    }
+    return httpClient.get(API_ENDPOINTS.FACILITY.BOOKINGS.RANGE, query);
   }
 
   async getBookingById(id: string): Promise<ApiResponse<BookingDetail>> {

--- a/src/pages/Facility/Booking/BookingDataPage.tsx
+++ b/src/pages/Facility/Booking/BookingDataPage.tsx
@@ -25,6 +25,7 @@ import BookingCancelForm from "./BookingCancelForm";
 import BookingDataForm, { type BookingDataFormHandle, type BookingFormValues } from "./BookingDataForm";
 import BookingDetailDrawer from "./BookingDetailDrawer";
 import BookingGrid from "./BookingGrid";
+import { loadBookingsForVisibleRange } from "./bookingOccupancyLoad";
 import { resolveBookingSaveErrorMessage } from "./bookingSaveError";
 
 type BookingRow = BookingListItem & Record<string, unknown>;
@@ -137,14 +138,9 @@ const BookingDataPage = () => {
     if (!visibleRange) return;
     setLoading(true);
     try {
-      const res = await facilityService.getBookingPages({
-        page: 0,
-        page_size: 200,
-        dateFrom: visibleRange.start.toISOString(),
-        dateTo: visibleRange.end.toISOString(),
-      });
-      if (res.success) {
-        setCalendarItems((res.data.items || []) as BookingRow[]);
+      const items = await loadBookingsForVisibleRange(facilityService, visibleRange);
+      if (items !== null) {
+        setCalendarItems(items as BookingRow[]);
       }
     } catch (error) {
       notifyApiError(error, {

--- a/src/pages/Facility/Booking/bookingOccupancyLoad.test.ts
+++ b/src/pages/Facility/Booking/bookingOccupancyLoad.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiResponse } from "@/types/api";
+import type { BookingListItem, BookingRangeParams } from "@/api/services/facilityService";
+import { loadBookingsForVisibleRange } from "./bookingOccupancyLoad";
+
+describe("loadBookingsForVisibleRange", () => {
+  it("loads via the booking range client for the visible window", async () => {
+    const items: BookingListItem[] = [
+      {
+        id: "booking-1",
+        userId: "user-1",
+        bookingType: "personal",
+        startAt: "2026-08-17T14:00:00.000Z",
+        endAt: "2026-08-17T16:00:00.000Z",
+        status: "confirmed",
+      },
+    ];
+    const getBookingRange = vi.fn(
+      async (_params: BookingRangeParams): Promise<ApiResponse<{ items: BookingListItem[] }>> => ({
+        success: true,
+        data: { items },
+      })
+    );
+
+    const result = await loadBookingsForVisibleRange(
+      { getBookingRange },
+      {
+        start: new Date("2026-08-17T00:00:00.000Z"),
+        end: new Date("2026-08-24T00:00:00.000Z"),
+      }
+    );
+
+    expect(getBookingRange).toHaveBeenCalledTimes(1);
+    expect(getBookingRange).toHaveBeenCalledWith({
+      dateFrom: "2026-08-17T00:00:00.000Z",
+      dateTo: "2026-08-24T00:00:00.000Z",
+    });
+    expect(result).toEqual(items);
+  });
+
+  it("returns null when the range response is unsuccessful", async () => {
+    const getBookingRange = vi.fn(async () => ({
+      success: false,
+      data: { items: [] },
+    }));
+
+    const result = await loadBookingsForVisibleRange(
+      { getBookingRange },
+      {
+        start: new Date("2026-08-17T00:00:00.000Z"),
+        end: new Date("2026-08-18T00:00:00.000Z"),
+      }
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/pages/Facility/Booking/bookingOccupancyLoad.test.ts
+++ b/src/pages/Facility/Booking/bookingOccupancyLoad.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
-import type { ApiResponse } from "@/types/api";
 import type { BookingListItem, BookingRangeParams } from "@/api/services/facilityService";
+import type { ApiResponse } from "@/types/api";
+import { describe, expect, it, vi } from "vitest";
 import { loadBookingsForVisibleRange } from "./bookingOccupancyLoad";
 
 describe("loadBookingsForVisibleRange", () => {

--- a/src/pages/Facility/Booking/bookingOccupancyLoad.ts
+++ b/src/pages/Facility/Booking/bookingOccupancyLoad.ts
@@ -1,0 +1,29 @@
+import type { BookingListItem, BookingRangeParams } from "@/api/services/facilityService";
+import type { ApiResponse } from "@/types/api";
+
+export type BookingRangeClient = {
+  getBookingRange: (params: BookingRangeParams) => Promise<ApiResponse<{ items: BookingListItem[] }>>;
+};
+
+export type VisibleBookingRange = {
+  start: Date;
+  end: Date;
+};
+
+/**
+ * Calendar / Grid occupancy load: complete window via Booking range query (not List pages).
+ * Returns null when the response is unsuccessful so callers can keep the last good window.
+ */
+export const loadBookingsForVisibleRange = async (
+  client: BookingRangeClient,
+  range: VisibleBookingRange
+): Promise<BookingListItem[] | null> => {
+  const response = await client.getBookingRange({
+    dateFrom: range.start.toISOString(),
+    dateTo: range.end.toISOString(),
+  });
+  if (!response.success) {
+    return null;
+  }
+  return response.data.items ?? [];
+};


### PR DESCRIPTION
## Summary

Calendar and Grid occupancy loads now use the core Booking range query (`/facility/bookings/range`) instead of List `pages` with a fixed large `page_size`, so the visible window is a complete overlap set. List view still uses paginated `pages`.

Closes #30

## Type of change

- [x] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Added `facilityService.getBookingRange` and `BOOKINGS.RANGE` endpoint.
- Calendar/Grid load through `loadBookingsForVisibleRange` (omit `includeCancelled` so cancelled rows stay off via server default).
- Soft unsuccessful responses return `null` so the last good occupancy window is kept.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] `pnpm run format:check` (CI)

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)