### PR TITLE
feat: add Calendar month layout with URL layout persistence

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,12 +1,21 @@
 import { useEffect, useState } from "react";
 import CalendarToolBar from "./CalendarToolbar";
 import DayView from "./DayView";
+import { shiftMonthPreservingDay } from "./monthLayout";
 import MonthView from "./MonthView";
 import { CalendarProps, CalendarView } from "./types";
 import WeekView from "./WeekView";
 
+const resolveInitialView = (availableViews: CalendarView[], preferred: CalendarView): CalendarView => {
+  if (availableViews.includes(preferred)) {
+    return preferred;
+  }
+  return availableViews[0] || "month";
+};
+
 const Calendar = ({
   currentDate = new Date(),
+  view,
   defaultView = "month",
   availableViews = ["day", "week", "month"],
   events = [],
@@ -25,16 +34,10 @@ const Calendar = ({
     setSelectedDate(currentDate);
   }, [currentDate]);
 
-  // Validate and set initial view
-  const getInitialView = (): CalendarView => {
-    if (availableViews.includes(defaultView)) {
-      return defaultView;
-    }
-    // If defaultView is not in availableViews, use the first available view
-    return availableViews[0] || "month";
-  };
-
-  const [currentView, setCurrentView] = useState<CalendarView>(getInitialView());
+  const [uncontrolledView, setUncontrolledView] = useState<CalendarView>(() =>
+    resolveInitialView(availableViews, defaultView)
+  );
+  const currentView = view !== undefined ? resolveInitialView(availableViews, view) : uncontrolledView;
 
   // Get showNavigationButtons value based on current view
   const getShowNavigationButtons = (): { nav: boolean; dateControl: boolean } => {
@@ -65,7 +68,9 @@ const Calendar = ({
   useEffect(() => {
     if (!availableViews.includes(currentView)) {
       const fallbackView = availableViews[0] || "month";
-      setCurrentView(fallbackView);
+      if (view === undefined) {
+        setUncontrolledView(fallbackView);
+      }
       onViewChange?.(fallbackView);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -77,40 +82,50 @@ const Calendar = ({
   };
 
   const handleViewChange = (newView: CalendarView) => {
-    setCurrentView(newView);
+    if (view === undefined) {
+      setUncontrolledView(newView);
+    }
     onViewChange?.(newView);
   };
 
   const handlePrevious = () => {
-    const newDate = new Date(selectedDate);
     switch (currentView) {
-      case "day":
+      case "day": {
+        const newDate = new Date(selectedDate);
         newDate.setDate(newDate.getDate() - 1);
+        handleDateChange(newDate);
         break;
-      case "week":
+      }
+      case "week": {
+        const newDate = new Date(selectedDate);
         newDate.setDate(newDate.getDate() - 7);
+        handleDateChange(newDate);
         break;
+      }
       case "month":
-        newDate.setMonth(newDate.getMonth() - 1);
+        handleDateChange(shiftMonthPreservingDay(selectedDate, -1));
         break;
     }
-    handleDateChange(newDate);
   };
 
   const handleNext = () => {
-    const newDate = new Date(selectedDate);
     switch (currentView) {
-      case "day":
+      case "day": {
+        const newDate = new Date(selectedDate);
         newDate.setDate(newDate.getDate() + 1);
+        handleDateChange(newDate);
         break;
-      case "week":
+      }
+      case "week": {
+        const newDate = new Date(selectedDate);
         newDate.setDate(newDate.getDate() + 7);
+        handleDateChange(newDate);
         break;
+      }
       case "month":
-        newDate.setMonth(newDate.getMonth() + 1);
+        handleDateChange(shiftMonthPreservingDay(selectedDate, 1));
         break;
     }
-    handleDateChange(newDate);
   };
 
   const renderView = () => {

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdAdd } from "react-icons/md";
+import { cn } from "@/utils";
 import DensityOverflowControl from "./DensityOverflowControl";
 import EventBlock from "./EventBlock";
 import { packDayEventLanes } from "./packDayEventLanes";
@@ -18,6 +19,8 @@ const DayView = ({
   onEventContextMenu,
   onAddEvent,
   onDensityOverflow,
+  showMiniMonth = true,
+  embedded = false,
 }: CalendarViewProps) => {
   const { t, i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
@@ -147,7 +150,12 @@ const DayView = ({
   };
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden border border-gray-300 dark:border-white/10 rounded-b-2xl">
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 overflow-hidden",
+        !embedded && "rounded-b-2xl border border-gray-300 dark:border-white/10"
+      )}
+    >
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div className="relative flex min-h-0 flex-1 overflow-y-auto">
           {/* Left time axis */}
@@ -264,89 +272,91 @@ const DayView = ({
           </div>
         </div>
       </div>
-      <div className="w-1/2 max-w-md flex-none border-l border-gray-100 px-8 py-10 dark:border-white/10">
-        <div className="flex items-center text-center text-gray-900 dark:text-white">
-          <button
-            type="button"
-            onClick={handleMiniCalendarPrevious}
-            className="-m-1.5 flex flex-none items-center justify-center p-1.5 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white"
-          >
-            <span className="sr-only">{t("nav.previousMonth")}</span>
-            <svg className="size-5" viewBox="0 0 20 20" fill="currentColor">
-              <path
-                fillRule="evenodd"
-                d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
-          <div className="flex-auto text-sm font-semibold">{formatDate(miniCalendarMonth, "month-year", locale)}</div>
-          <button
-            type="button"
-            onClick={handleMiniCalendarNext}
-            className="-m-1.5 flex flex-none items-center justify-center p-1.5 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white"
-          >
-            <span className="sr-only">{t("nav.nextMonth")}</span>
-            <svg className="size-5" viewBox="0 0 20 20" fill="currentColor">
-              <path
-                fillRule="evenodd"
-                d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
-        </div>
-        <div className="mt-6 grid grid-cols-7 text-center text-xs/6 text-gray-500 dark:text-gray-400">
-          {Array.from({ length: 7 }, (_, index) => {
-            const date = new Date(2024, 0, 7 + index); // Sunday-start
-            const label = date.toLocaleDateString(locale, { weekday: "narrow" });
-            return <div key={`mini-weekday-${index}`}>{label}</div>;
-          })}
-        </div>
-        <div className="isolate mt-2 grid grid-cols-7 gap-px rounded-lg bg-gray-200 text-sm shadow-sm ring-1 ring-gray-200 dark:bg-white/10 dark:shadow-none dark:ring-white/10">
-          {miniCalendarDays.map((day) => {
-            // Parse date string (YYYY-MM-DD) as local time
-            const [year, month, dayNum] = day.date.split("-").map(Number);
-            const dayDate = new Date(year, month - 1, dayNum);
+      {showMiniMonth && (
+        <div className="w-1/2 max-w-md flex-none border-l border-gray-100 px-8 py-10 dark:border-white/10">
+          <div className="flex items-center text-center text-gray-900 dark:text-white">
+            <button
+              type="button"
+              onClick={handleMiniCalendarPrevious}
+              className="-m-1.5 flex flex-none items-center justify-center p-1.5 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white"
+            >
+              <span className="sr-only">{t("nav.previousMonth")}</span>
+              <svg className="size-5" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+            <div className="flex-auto text-sm font-semibold">{formatDate(miniCalendarMonth, "month-year", locale)}</div>
+            <button
+              type="button"
+              onClick={handleMiniCalendarNext}
+              className="-m-1.5 flex flex-none items-center justify-center p-1.5 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white"
+            >
+              <span className="sr-only">{t("nav.nextMonth")}</span>
+              <svg className="size-5" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
+          <div className="mt-6 grid grid-cols-7 text-center text-xs/6 text-gray-500 dark:text-gray-400">
+            {Array.from({ length: 7 }, (_, index) => {
+              const date = new Date(2024, 0, 7 + index); // Sunday-start
+              const label = date.toLocaleDateString(locale, { weekday: "narrow" });
+              return <div key={`mini-weekday-${index}`}>{label}</div>;
+            })}
+          </div>
+          <div className="isolate mt-2 grid grid-cols-7 gap-px rounded-lg bg-gray-200 text-sm shadow-sm ring-1 ring-gray-200 dark:bg-white/10 dark:shadow-none dark:ring-white/10">
+            {miniCalendarDays.map((day) => {
+              // Parse date string (YYYY-MM-DD) as local time
+              const [year, month, dayNum] = day.date.split("-").map(Number);
+              const dayDate = new Date(year, month - 1, dayNum);
 
-            // Normalize currentDate to local timezone for comparison
-            const normalizedCurrentDate = new Date(
-              currentDate.getFullYear(),
-              currentDate.getMonth(),
-              currentDate.getDate()
-            );
-            const normalizedDayDate = new Date(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate());
-            const isSelected = normalizedDayDate.getTime() === normalizedCurrentDate.getTime();
-            const isToday = day.isToday;
+              // Normalize currentDate to local timezone for comparison
+              const normalizedCurrentDate = new Date(
+                currentDate.getFullYear(),
+                currentDate.getMonth(),
+                currentDate.getDate()
+              );
+              const normalizedDayDate = new Date(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate());
+              const isSelected = normalizedDayDate.getTime() === normalizedCurrentDate.getTime();
+              const isToday = day.isToday;
 
-            const isInRange = isDateInRange(dayDate, validRange);
-            const isDisabled = !isInRange;
+              const isInRange = isDateInRange(dayDate, validRange);
+              const isDisabled = !isInRange;
 
-            return (
-              <button
-                key={day.date}
-                type="button"
-                onClick={() => handleDayClick(day.date)}
-                disabled={isDisabled}
-                data-is-today={isToday ? "" : undefined}
-                data-is-selected={isSelected ? "" : undefined}
-                data-is-current-month={day.isCurrentMonth ? "" : undefined}
-                data-is-disabled={isDisabled ? "" : undefined}
-                className={`py-1.5 not-data-is-current-month:bg-gray-50 not-data-is-selected:not-data-is-current-month:not-data-is-today:text-gray-400 first:rounded-tl-lg last:rounded-br-lg hover:bg-gray-100 focus:z-10 data-is-current-month:bg-white not-data-is-selected:data-is-current-month:not-data-is-today:text-gray-900 data-is-current-month:hover:bg-gray-100 data-is-selected:font-semibold data-is-selected:text-white data-is-today:font-semibold data-is-today:not-data-is-selected:text-indigo-600 nth-36:rounded-bl-lg nth-7:rounded-tr-lg dark:not-data-is-current-month:bg-gray-900/75 dark:not-data-is-selected:not-data-is-current-month:not-data-is-today:text-gray-500 dark:hover:bg-gray-900/25 dark:data-is-current-month:bg-gray-900/90 dark:not-data-is-selected:data-is-current-month:not-data-is-today:text-white dark:data-is-current-month:hover:bg-gray-900/50 dark:data-is-selected:text-gray-900 dark:data-is-today:not-data-is-selected:text-indigo-400 ${
-                  isDisabled ? "opacity-50 cursor-not-allowed" : ""
-                }`}
-              >
-                <time
-                  dateTime={day.date}
-                  className="mx-auto flex size-7 items-center justify-center rounded-full in-data-is-selected:not-in-data-is-today:bg-gray-900 in-data-is-selected:in-data-is-today:bg-indigo-600 dark:in-data-is-selected:not-in-data-is-today:bg-white dark:in-data-is-selected:in-data-is-today:bg-indigo-500"
+              return (
+                <button
+                  key={day.date}
+                  type="button"
+                  onClick={() => handleDayClick(day.date)}
+                  disabled={isDisabled}
+                  data-is-today={isToday ? "" : undefined}
+                  data-is-selected={isSelected ? "" : undefined}
+                  data-is-current-month={day.isCurrentMonth ? "" : undefined}
+                  data-is-disabled={isDisabled ? "" : undefined}
+                  className={`py-1.5 not-data-is-current-month:bg-gray-50 not-data-is-selected:not-data-is-current-month:not-data-is-today:text-gray-400 first:rounded-tl-lg last:rounded-br-lg hover:bg-gray-100 focus:z-10 data-is-current-month:bg-white not-data-is-selected:data-is-current-month:not-data-is-today:text-gray-900 data-is-current-month:hover:bg-gray-100 data-is-selected:font-semibold data-is-selected:text-white data-is-today:font-semibold data-is-today:not-data-is-selected:text-indigo-600 nth-36:rounded-bl-lg nth-7:rounded-tr-lg dark:not-data-is-current-month:bg-gray-900/75 dark:not-data-is-selected:not-data-is-current-month:not-data-is-today:text-gray-500 dark:hover:bg-gray-900/25 dark:data-is-current-month:bg-gray-900/90 dark:not-data-is-selected:data-is-current-month:not-data-is-today:text-white dark:data-is-current-month:hover:bg-gray-900/50 dark:data-is-selected:text-gray-900 dark:data-is-today:not-data-is-selected:text-indigo-400 ${
+                    isDisabled ? "opacity-50 cursor-not-allowed" : ""
+                  }`}
                 >
-                  {day.date.split("-").pop()?.replace(/^0/, "") || ""}
-                </time>
-              </button>
-            );
-          })}
+                  <time
+                    dateTime={day.date}
+                    className="mx-auto flex size-7 items-center justify-center rounded-full in-data-is-selected:not-in-data-is-today:bg-gray-900 in-data-is-selected:in-data-is-today:bg-indigo-600 dark:in-data-is-selected:not-in-data-is-today:bg-white dark:in-data-is-selected:in-data-is-today:bg-indigo-500"
+                  >
+                    {day.date.split("-").pop()?.replace(/^0/, "") || ""}
+                  </time>
+                </button>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -1,7 +1,7 @@
+import { cn } from "@/utils";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdAdd } from "react-icons/md";
-import { cn } from "@/utils";
 import DensityOverflowControl from "./DensityOverflowControl";
 import EventBlock from "./EventBlock";
 import { packDayEventLanes } from "./packDayEventLanes";

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -1,127 +1,227 @@
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CalendarViewProps } from "./types";
-import { filterEventsByDate, formatWeekday, getMonthDays, isDateInRange } from "./utils";
+import { cn } from "@/utils";
+import DayView from "./DayView";
+import { formatEventTimeClock } from "./formatEventTime";
+import { DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX, monthCellSummaryCapacity } from "./monthLayout";
+import { CalendarEvent, CalendarViewProps } from "./types";
+import { filterEventsByDateRange, formatWeekday, getMonthDays, isDateInRange } from "./utils";
 
-const MonthView = ({ currentDate, events = [], validRange, onEventClick, onDateChange }: CalendarViewProps) => {
-  const { i18n } = useTranslation("calendar");
+const DAY_NUMBER_RESERVE_PX = 28;
+const CELL_VERTICAL_PADDING_PX = 16;
+
+const eventsForDay = (events: CalendarEvent[], dayDate: Date): CalendarEvent[] => {
+  return filterEventsByDateRange(events, dayDate, dayDate).sort((a, b) => {
+    const aStart = a.start instanceof Date ? a.start : new Date(a.start);
+    const bStart = b.start instanceof Date ? b.start : new Date(b.start);
+    return aStart.getTime() - bStart.getTime();
+  });
+};
+
+const parseLocalDate = (dateStr: string): Date => {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  return new Date(year, month - 1, day);
+};
+
+const visibleSummariesForCell = (
+  dayEvents: CalendarEvent[],
+  contentHeightPx: number
+): { visibleEvents: CalendarEvent[]; hiddenCount: number } => {
+  const hasEvents = dayEvents.length > 0;
+  if (!hasEvents) {
+    return { visibleEvents: [], hiddenCount: 0 };
+  }
+
+  const totalLines = monthCellSummaryCapacity(contentHeightPx, {
+    lineHeightPx: DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX,
+    hasEvents: true,
+  });
+
+  if (dayEvents.length <= totalLines) {
+    return { visibleEvents: dayEvents.slice(0, totalLines), hiddenCount: 0 };
+  }
+
+  // Reserve one line for "+ N more" when more than one line fits; if only one line
+  // fits, that line is the more control (no summary overflow).
+  if (totalLines === 1) {
+    return { visibleEvents: [], hiddenCount: dayEvents.length };
+  }
+
+  const visibleEvents = dayEvents.slice(0, totalLines - 1);
+  return {
+    visibleEvents,
+    hiddenCount: dayEvents.length - visibleEvents.length,
+  };
+};
+
+const MonthView = ({
+  currentDate,
+  events = [],
+  validRange,
+  onEventClick,
+  onEventContextMenu,
+  onDateChange,
+  onAddEvent,
+  onDensityOverflow,
+}: CalendarViewProps) => {
+  const { t, i18n } = useTranslation("calendar");
   const locale = i18n.language || "en";
   const days = getMonthDays(currentDate);
+  const measureCellRef = useRef<HTMLDivElement>(null);
+  const [contentHeightPx, setContentHeightPx] = useState(0);
 
-  // Weekday labels - always start with Sunday
+  useEffect(() => {
+    const el = measureCellRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      setContentHeightPx(Math.max(0, el.clientHeight - DAY_NUMBER_RESERVE_PX - CELL_VERTICAL_PADDING_PX));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [currentDate]);
+
   const weekdayLabels = Array.from({ length: 7 }, (_, index) => {
-    const date = new Date(2024, 0, 7 + index); // 2024-01-07 is Sunday
+    const date = new Date(2024, 0, 7 + index);
     return formatWeekday(date, "short", locale);
   });
 
-  const getEventsForDay = (date: string) => {
-    return filterEventsByDate(events, new Date(date));
-  };
-
-  const handleDayClick = (date: string) => {
-    // Parse date string (YYYY-MM-DD) as local time, not UTC
-    const [year, month, day] = date.split("-").map(Number);
-    const newDate = new Date(year, month - 1, day);
-    // Check if date is within valid range
-    if (isDateInRange(newDate, validRange)) {
-      onDateChange(newDate);
+  const handleDaySelect = (dateStr: string) => {
+    const next = parseLocalDate(dateStr);
+    if (isDateInRange(next, validRange)) {
+      onDateChange(next);
     }
   };
 
+  const normalizedCurrent = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
+
   return (
-    <div className="flex flex-auto flex-col rounded-b-2xl border-x border-b border-gray-300 dark:border-white/10">
-      <div className="grid grid-cols-7 gap-px border-b border-gray-300 bg-gray-200 text-center text-xs/6 font-semibold text-gray-700 flex-none dark:border-white/5 dark:bg-white/15 dark:text-gray-300">
-        {weekdayLabels.map((label, index) => (
-          <div key={`${label}-${index}`} className="flex justify-center bg-white py-2 dark:bg-gray-900">
-            <span>{label}</span>
-          </div>
-        ))}
-      </div>
-      <div className="flex bg-gray-200 text-xs/6 text-gray-700 flex-auto dark:bg-white/10 dark:text-gray-300 overflow-hidden rounded-b-2xl">
-        <div className="w-full grid grid-cols-7 grid-rows-6 gap-px">
-          {days.map((day) => {
-            const dayEvents = getEventsForDay(day.date);
-            // Check if this day is selected (parse as local time)
-            const [year, month, dayNum] = day.date.split("-").map(Number);
-            const date = new Date(year, month - 1, dayNum);
-            date.setHours(0, 0, 0, 0);
-            const normalizedCurrentDate = new Date(currentDate);
-            normalizedCurrentDate.setHours(0, 0, 0, 0);
-            const isSelected = date.getTime() === normalizedCurrentDate.getTime();
-            const isToday = day.isToday;
+    <div className="flex min-h-0 flex-1 overflow-hidden rounded-b-2xl border-x border-b border-gray-300 dark:border-white/10">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="grid flex-none grid-cols-7 gap-px border-b border-gray-300 bg-gray-200 text-center text-xs/6 font-semibold text-gray-700 dark:border-white/5 dark:bg-white/15 dark:text-gray-300">
+          {weekdayLabels.map((label, index) => (
+            <div key={`${label}-${index}`} className="flex justify-center bg-white py-2 dark:bg-gray-900">
+              <span>{label}</span>
+            </div>
+          ))}
+        </div>
+        <div className="flex min-h-0 flex-auto overflow-hidden bg-gray-200 text-xs/6 text-gray-700 dark:bg-white/10 dark:text-gray-300">
+          <div className="grid w-full grid-cols-7 grid-rows-6 gap-px">
+            {days.map((day, index) => {
+              const dayDate = parseLocalDate(day.date);
+              const dayEvents = eventsForDay(events, dayDate);
+              const isSelected = dayDate.getTime() === normalizedCurrent.getTime();
+              const isToday = !!day.isToday;
+              const isDisabled = !isDateInRange(dayDate, validRange);
+              const { visibleEvents, hiddenCount } = visibleSummariesForCell(dayEvents, contentHeightPx);
+              const hasEvents = dayEvents.length > 0;
 
-            const dayDate = new Date(year, month - 1, dayNum);
-            const isInRange = isDateInRange(dayDate, validRange);
-            const isDisabled = !isInRange;
-
-            return (
-              <div
-                key={day.date}
-                data-is-today={isToday ? "" : undefined}
-                data-is-selected={isSelected ? "" : undefined}
-                data-is-current-month={day.isCurrentMonth ? "" : undefined}
-                data-is-disabled={isDisabled ? "" : undefined}
-                className={`group relative bg-gray-50 px-3 py-2 text-gray-500 data-is-current-month:bg-white dark:bg-gray-900 dark:text-gray-400 dark:not-data-is-current-month:before:pointer-events-none dark:not-data-is-current-month:before:absolute dark:not-data-is-current-month:before:inset-0 dark:not-data-is-current-month:before:bg-gray-800/50 dark:data-is-current-month:bg-gray-900 data-is-current-month:hover:bg-gray-100 dark:data-is-current-month:hover:bg-gray-800/50 data-is-current-month:cursor-pointer transition-colors ${
-                  isDisabled ? "opacity-50 cursor-not-allowed" : ""
-                }`}
-                onClick={() => {
-                  if (day.isCurrentMonth && !isDisabled) {
-                    handleDayClick(day.date);
-                  }
-                }}
-              >
-                <time
-                  dateTime={day.date}
-                  className={`relative group-not-data-is-current-month:opacity-75 ${
-                    isToday
-                      ? "flex size-6 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white dark:bg-indigo-500"
-                      : isSelected
-                        ? "flex size-6 items-center justify-center rounded-full bg-gray-900 font-semibold text-white dark:bg-white dark:text-gray-900"
-                        : ""
-                  }`}
+              return (
+                <div
+                  key={day.date}
+                  ref={index === 0 ? measureCellRef : undefined}
+                  data-is-today={isToday ? "" : undefined}
+                  data-is-selected={isSelected ? "" : undefined}
+                  data-is-current-month={day.isCurrentMonth ? "" : undefined}
+                  data-is-disabled={isDisabled ? "" : undefined}
+                  className={cn(
+                    "group relative cursor-pointer bg-gray-50 px-2 py-2 text-gray-500 transition-colors data-is-current-month:bg-white data-is-current-month:hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-400 dark:not-data-is-current-month:before:pointer-events-none dark:not-data-is-current-month:before:absolute dark:not-data-is-current-month:before:inset-0 dark:not-data-is-current-month:before:bg-gray-800/50 dark:data-is-current-month:bg-gray-900 dark:data-is-current-month:hover:bg-gray-800/50",
+                    isDisabled && "cursor-not-allowed opacity-50",
+                    !day.isCurrentMonth && "opacity-75"
+                  )}
+                  onClick={() => {
+                    if (!isDisabled) {
+                      handleDaySelect(day.date);
+                    }
+                  }}
                 >
-                  {day.date.split("-").pop()?.replace(/^0/, "") || ""}
-                </time>
-                {dayEvents.length > 0 ? (
-                  <ol className="mt-2">
-                    {dayEvents.slice(0, 2).map((event) => {
-                      const eventStart = new Date(event.start);
-                      const timeString = eventStart.toLocaleTimeString(locale, {
-                        hour: "numeric",
-                        minute: "2-digit",
-                        hour12: locale.startsWith("en"),
-                      });
-                      return (
-                        <li key={event.id}>
+                  <time
+                    dateTime={day.date}
+                    className={cn(
+                      "relative inline-flex size-6 items-center justify-center",
+                      isToday && "rounded-full bg-brand-500 font-semibold text-white dark:bg-brand-500",
+                      !isToday &&
+                        isSelected &&
+                        "rounded-full bg-gray-900 font-semibold text-white dark:bg-white dark:text-gray-900"
+                    )}
+                  >
+                    {day.date.split("-").pop()?.replace(/^0/, "") || ""}
+                  </time>
+                  {hasEvents ? (
+                    <ol className="mt-1 space-y-0.5">
+                      {visibleEvents.map((event) => {
+                        const eventStart = event.start instanceof Date ? event.start : new Date(event.start);
+                        const timeString = formatEventTimeClock(eventStart, locale);
+                        return (
+                          <li key={event.id}>
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDaySelect(day.date);
+                                onEventClick?.(event);
+                              }}
+                              onContextMenu={(e) => {
+                                e.stopPropagation();
+                                onEventContextMenu?.(event, e);
+                              }}
+                              className="group/summary flex w-full min-w-0 items-center gap-1 text-left"
+                            >
+                              <span
+                                aria-hidden
+                                className="size-1.5 flex-none rounded-full bg-brand-500 dark:bg-brand-400"
+                              />
+                              <time
+                                dateTime={eventStart.toISOString()}
+                                className="flex-none text-[11px] text-gray-500 group-hover/summary:text-brand-600 dark:text-gray-400 dark:group-hover/summary:text-brand-400"
+                              >
+                                {timeString}
+                              </time>
+                              <span className="min-w-0 flex-auto truncate text-[11px] font-medium text-gray-900 group-hover/summary:text-brand-600 dark:text-white dark:group-hover/summary:text-brand-400">
+                                {event.title}
+                              </span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                      {hiddenCount > 0 ? (
+                        <li>
                           <button
                             type="button"
                             onClick={(e) => {
                               e.stopPropagation();
-                              onEventClick?.(event);
+                              handleDaySelect(day.date);
                             }}
-                            className="group flex w-full text-left"
+                            className="text-[11px] text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400"
                           >
-                            <p className="flex-auto truncate font-medium text-gray-900 group-hover:text-indigo-600 dark:text-white dark:group-hover:text-indigo-400">
-                              {event.title}
-                            </p>
-                            <time
-                              dateTime={eventStart.toISOString()}
-                              className="ml-3 flex-none text-gray-500 group-hover:text-indigo-600 dark:text-gray-400 dark:group-hover:text-indigo-400"
-                            >
-                              {timeString}
-                            </time>
+                            {t("month.moreSummaries", { count: hiddenCount })}
                           </button>
                         </li>
-                      );
-                    })}
-                    {dayEvents.length > 2 ? (
-                      <li className="text-gray-500 dark:text-gray-400">+ {dayEvents.length - 2} more</li>
-                    ) : null}
-                  </ol>
-                ) : null}
-              </div>
-            );
-          })}
+                      ) : null}
+                    </ol>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
         </div>
+      </div>
+      <div className="flex min-h-0 w-[42%] min-w-[18rem] max-w-xl flex-none flex-col overflow-hidden border-l border-gray-300 dark:border-white/10">
+        <DayView
+          currentDate={currentDate}
+          events={events}
+          validRange={validRange}
+          onDateChange={onDateChange}
+          onEventClick={onEventClick}
+          onEventContextMenu={onEventContextMenu}
+          onAddEvent={onAddEvent}
+          onDensityOverflow={onDensityOverflow}
+          showMiniMonth={false}
+          embedded
+        />
       </div>
     </div>
   );

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -1,6 +1,6 @@
+import { cn } from "@/utils";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { cn } from "@/utils";
 import DayView from "./DayView";
 import { formatEventTimeClock } from "./formatEventTime";
 import { DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX, monthCellSummaryCapacity } from "./monthLayout";
@@ -128,7 +128,7 @@ const MonthView = ({
                   data-is-current-month={day.isCurrentMonth ? "" : undefined}
                   data-is-disabled={isDisabled ? "" : undefined}
                   className={cn(
-                    "group relative cursor-pointer bg-gray-50 px-2 py-2 text-gray-500 transition-colors data-is-current-month:bg-white data-is-current-month:hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-400 dark:not-data-is-current-month:before:pointer-events-none dark:not-data-is-current-month:before:absolute dark:not-data-is-current-month:before:inset-0 dark:not-data-is-current-month:before:bg-gray-800/50 dark:data-is-current-month:bg-gray-900 dark:data-is-current-month:hover:bg-gray-800/50",
+                    "relative cursor-pointer bg-gray-50 px-1 py-1 text-gray-500 data-is-current-month:bg-white dark:bg-gray-900 dark:text-gray-400 dark:not-data-is-current-month:before:pointer-events-none dark:not-data-is-current-month:before:absolute dark:not-data-is-current-month:before:inset-0 dark:not-data-is-current-month:before:bg-gray-800/50 dark:data-is-current-month:bg-gray-900",
                     isDisabled && "cursor-not-allowed opacity-50",
                     !day.isCurrentMonth && "opacity-75"
                   )}
@@ -141,17 +141,16 @@ const MonthView = ({
                   <time
                     dateTime={day.date}
                     className={cn(
-                      "relative inline-flex size-6 items-center justify-center",
-                      isToday && "rounded-full bg-brand-500 font-semibold text-white dark:bg-brand-500",
-                      !isToday &&
-                        isSelected &&
-                        "rounded-full bg-gray-900 font-semibold text-white dark:bg-white dark:text-gray-900"
+                      "relative inline-flex size-6 items-center justify-center rounded-full transition-colors",
+                      isToday && "bg-brand-500 font-semibold text-white dark:bg-brand-500",
+                      !isToday && isSelected && "bg-gray-900 font-semibold text-white dark:bg-white dark:text-gray-900",
+                      !isToday && !isSelected && !isDisabled && "hover:bg-gray-200 dark:hover:bg-white/15"
                     )}
                   >
                     {day.date.split("-").pop()?.replace(/^0/, "") || ""}
                   </time>
                   {hasEvents ? (
-                    <ol className="mt-1 space-y-0.5">
+                    <ol className="mt-0.5 space-y-0 leading-none">
                       {visibleEvents.map((event) => {
                         const eventStart = event.start instanceof Date ? event.start : new Date(event.start);
                         const timeString = formatEventTimeClock(eventStart, locale);
@@ -168,19 +167,19 @@ const MonthView = ({
                                 e.stopPropagation();
                                 onEventContextMenu?.(event, e);
                               }}
-                              className="group/summary flex w-full min-w-0 items-center gap-1 text-left"
+                              className="-mx-0.5 flex w-[calc(100%+0.25rem)] min-w-0 items-center gap-0.5 rounded px-0.5 py-px text-left text-[12px] leading-tight transition-colors hover:bg-gray-100 dark:hover:bg-white/10"
                             >
                               <span
                                 aria-hidden
-                                className="size-1.5 flex-none rounded-full bg-brand-500 dark:bg-brand-400"
+                                className="size-1 flex-none rounded-full bg-brand-500 dark:bg-brand-400"
                               />
                               <time
                                 dateTime={eventStart.toISOString()}
-                                className="flex-none text-[11px] text-gray-500 group-hover/summary:text-brand-600 dark:text-gray-400 dark:group-hover/summary:text-brand-400"
+                                className="flex-none text-gray-500 dark:text-gray-400"
                               >
                                 {timeString}
                               </time>
-                              <span className="min-w-0 flex-auto truncate text-[11px] font-medium text-gray-900 group-hover/summary:text-brand-600 dark:text-white dark:group-hover/summary:text-brand-400">
+                              <span className="ml-0.5 min-w-0 flex-auto truncate font-medium text-gray-900 dark:text-white">
                                 {event.title}
                               </span>
                             </button>
@@ -195,7 +194,7 @@ const MonthView = ({
                               e.stopPropagation();
                               handleDaySelect(day.date);
                             }}
-                            className="text-[11px] text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400"
+                            className="px-0.5 py-px text-[12px] leading-tight text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400"
                           >
                             {t("month.moreSummaries", { count: hiddenCount })}
                           </button>

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -11,5 +11,6 @@ export type {
   CalendarViewProps,
   EventHorizontalLayout,
 } from "./types";
+export * from "./monthLayout";
 export * from "./utils";
 export { default as WeekView } from "./WeekView";

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -1,6 +1,7 @@
 export { default as Calendar } from "./Calendar";
 export { default as CalendarToolBar } from "./CalendarToolbar";
 export { default as DayView } from "./DayView";
+export * from "./monthLayout";
 export { default as MonthView } from "./MonthView";
 export type {
   CalendarDay,
@@ -11,6 +12,5 @@ export type {
   CalendarViewProps,
   EventHorizontalLayout,
 } from "./types";
-export * from "./monthLayout";
 export * from "./utils";
 export { default as WeekView } from "./WeekView";

--- a/src/components/calendar/monthLayout.test.ts
+++ b/src/components/calendar/monthLayout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getVisibleMonthWindow, monthCellSummaryCapacity, shiftMonthPreservingDay } from "./monthLayout";
+import { formatDateString, getMonthDays } from "./utils";
+
+describe("getVisibleMonthWindow", () => {
+  it("returns the Sunday-start 6x7 window including adjacent-month padding", () => {
+    // August 2026 starts on Saturday; grid starts Sunday Jul 26 and ends Sat Sep 5
+    const window = getVisibleMonthWindow(new Date(2026, 7, 21));
+    expect(formatDateString(window.start)).toBe("2026-07-26");
+    expect(formatDateString(window.end)).toBe("2026-09-05");
+    expect(window.start.getHours()).toBe(0);
+    expect(window.end.getHours()).toBe(23);
+    expect(window.end.getMinutes()).toBe(59);
+
+    const days = getMonthDays(new Date(2026, 7, 21));
+    expect(days).toHaveLength(42);
+    expect(days[0]?.date).toBe(formatDateString(window.start));
+    expect(days[41]?.date).toBe("2026-09-05");
+  });
+});
+
+describe("monthCellSummaryCapacity", () => {
+  it("fits as many lines as the content height allows", () => {
+    expect(monthCellSummaryCapacity(54, { lineHeightPx: 18 })).toBe(3);
+    expect(monthCellSummaryCapacity(17, { lineHeightPx: 18 })).toBe(0);
+  });
+
+  it("keeps at least one line when the day has events", () => {
+    expect(monthCellSummaryCapacity(0, { lineHeightPx: 18, hasEvents: true })).toBe(1);
+    expect(monthCellSummaryCapacity(40, { lineHeightPx: 18, hasEvents: true })).toBe(2);
+  });
+});
+
+describe("shiftMonthPreservingDay", () => {
+  it("steps by one month and keeps day-of-month when possible", () => {
+    const next = shiftMonthPreservingDay(new Date(2026, 7, 21), 1);
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(8);
+    expect(next.getDate()).toBe(21);
+  });
+
+  it("clamps to the last day when the target month is shorter", () => {
+    const next = shiftMonthPreservingDay(new Date(2026, 0, 31), 1);
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(1);
+    expect(next.getDate()).toBe(28);
+  });
+});

--- a/src/components/calendar/monthLayout.ts
+++ b/src/components/calendar/monthLayout.ts
@@ -1,0 +1,63 @@
+import { getMonthDays } from "./utils";
+
+export const DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX = 18;
+
+/**
+ * Visible month grid window (Sunday-start 6x7) for the Calendar month layout.
+ * Includes adjacent-month padding days.
+ */
+export const getVisibleMonthWindow = (anchorDate: Date): { start: Date; end: Date } => {
+  const days = getMonthDays(anchorDate);
+  const first = days[0]?.date;
+  const last = days[days.length - 1]?.date;
+  if (!first || !last) {
+    const start = new Date(anchorDate);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(23, 59, 59, 999);
+    return { start, end };
+  }
+
+  const [startYear, startMonth, startDay] = first.split("-").map(Number);
+  const [endYear, endMonth, endDay] = last.split("-").map(Number);
+  const start = new Date(startYear, startMonth - 1, startDay, 0, 0, 0, 0);
+  const end = new Date(endYear, endMonth - 1, endDay, 23, 59, 59, 999);
+  return { start, end };
+};
+
+/**
+ * How many compact summary lines fit in a month cell's content area.
+ * When the day has events, capacity is at least one line.
+ */
+export const monthCellSummaryCapacity = (
+  availableHeightPx: number,
+  options?: {
+    lineHeightPx?: number;
+    hasEvents?: boolean;
+  }
+): number => {
+  const lineHeightPx = options?.lineHeightPx ?? DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX;
+  const hasEvents = options?.hasEvents ?? false;
+  if (lineHeightPx <= 0) {
+    return hasEvents ? 1 : 0;
+  }
+  const fitted = Math.floor(Math.max(0, availableHeightPx) / lineHeightPx);
+  if (hasEvents) {
+    return Math.max(1, fitted);
+  }
+  return fitted;
+};
+
+/**
+ * Step Calendar anchor by whole months, preserving day-of-month when possible
+ * (clamps to the last day of the target month).
+ */
+export const shiftMonthPreservingDay = (date: Date, deltaMonths: number): Date => {
+  const next = new Date(date);
+  const day = next.getDate();
+  next.setDate(1);
+  next.setMonth(next.getMonth() + deltaMonths);
+  const lastDay = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
+  next.setDate(Math.min(day, lastDay));
+  return next;
+};

--- a/src/components/calendar/monthLayout.ts
+++ b/src/components/calendar/monthLayout.ts
@@ -1,6 +1,6 @@
 import { getMonthDays } from "./utils";
 
-export const DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX = 18;
+export const DEFAULT_MONTH_SUMMARY_LINE_HEIGHT_PX = 16;
 
 /**
  * Visible month grid window (Sunday-start 6x7) for the Calendar month layout.

--- a/src/components/calendar/types.ts
+++ b/src/components/calendar/types.ts
@@ -40,6 +40,8 @@ export interface DateRange {
 
 export interface CalendarProps {
   currentDate?: Date;
+  /** Controlled Calendar layout. When set, overrides internal view state. */
+  view?: CalendarView;
   defaultView?: CalendarView;
   availableViews?: CalendarView[];
   events?: CalendarEvent[];
@@ -68,4 +70,8 @@ export interface CalendarViewProps {
   onEventContextMenu?: (event: CalendarEvent, mouseEvent: React.MouseEvent) => void;
   onAddEvent?: (date?: Date, startTime?: string, endTime?: string) => void;
   onDensityOverflow?: (date: Date) => void;
+  /** Day view only: when false, hide the right-hand mini month (used by Month split pane). */
+  showMiniMonth?: boolean;
+  /** When true, omit the standalone outer border chrome (embedded panes). */
+  embedded?: boolean;
 }

--- a/src/i18n/locales/en/calendar.json
+++ b/src/i18n/locales/en/calendar.json
@@ -12,6 +12,9 @@
   "addBooking": "Add booking",
   "densityOverflow": "{{count}} more — view in Grid",
   "densityOverflowAria": "Switch to Grid to see {{count}} hidden bookings",
+  "month": {
+    "moreSummaries": "+{{count}} more"
+  },
   "nav": {
     "previousDay": "Previous day",
     "previousWeek": "Previous week",

--- a/src/i18n/locales/zh-CN/calendar.json
+++ b/src/i18n/locales/zh-CN/calendar.json
@@ -12,6 +12,9 @@
   "addBooking": "新增预约",
   "densityOverflow": "另有 {{count}} 笔，改以 Grid 查看",
   "densityOverflowAria": "切换到 Grid 以查看未显示的 {{count}} 笔预约",
+  "month": {
+    "moreSummaries": "+{{count}} 笔"
+  },
   "nav": {
     "previousDay": "上一天",
     "previousWeek": "上一周",

--- a/src/i18n/locales/zh-TW/calendar.json
+++ b/src/i18n/locales/zh-TW/calendar.json
@@ -12,6 +12,9 @@
   "addBooking": "新增預約",
   "densityOverflow": "另有 {{count}} 筆，改以 Grid 檢視",
   "densityOverflowAria": "切換到 Grid 以查看未顯示的 {{count}} 筆預約",
+  "month": {
+    "moreSummaries": "+{{count}} 筆"
+  },
   "nav": {
     "previousDay": "上一天",
     "previousWeek": "上一週",

--- a/src/pages/Facility/Booking/BookingCalendar.tsx
+++ b/src/pages/Facility/Booking/BookingCalendar.tsx
@@ -1,12 +1,14 @@
 import type { BookingListItem } from "@/api/services/facilityService";
-import { Calendar, type CalendarEvent, type CalendarView } from "@/components/calendar";
+import { Calendar, getVisibleMonthWindow, type CalendarEvent, type CalendarView } from "@/components/calendar";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 interface BookingCalendarProps {
   anchorDate: Date;
+  calendarLayout: CalendarView;
   bookings: BookingListItem[];
   onAnchorDateChange: (date: Date) => void;
+  onCalendarLayoutChange: (layout: CalendarView) => void;
   onVisibleRangeChange: (range: { start: Date; end: Date }) => void;
   onEventClick: (booking: BookingListItem) => void;
   onCancelClick: (booking: BookingListItem) => void;
@@ -46,8 +48,10 @@ const endOfWeek = (date: Date): Date => {
 
 const BookingCalendar = ({
   anchorDate,
+  calendarLayout,
   bookings,
   onAnchorDateChange,
+  onCalendarLayoutChange,
   onVisibleRangeChange,
   onEventClick,
   onCancelClick,
@@ -55,7 +59,6 @@ const BookingCalendar = ({
   onDensityOverflow,
 }: BookingCalendarProps) => {
   const { t } = useTranslation("facility");
-  const [calendarLayout, setCalendarLayout] = useState<CalendarView>("week");
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -66,7 +69,9 @@ const BookingCalendar = ({
     const range =
       calendarLayout === "day"
         ? { start: startOfDay(anchorDate), end: endOfDay(anchorDate) }
-        : { start: startOfWeek(anchorDate), end: endOfWeek(anchorDate) };
+        : calendarLayout === "month"
+          ? getVisibleMonthWindow(anchorDate)
+          : { start: startOfWeek(anchorDate), end: endOfWeek(anchorDate) };
     onVisibleRangeChange(range);
   }, [anchorDate, calendarLayout, onVisibleRangeChange]);
 
@@ -103,11 +108,12 @@ const BookingCalendar = ({
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
       <Calendar
         currentDate={anchorDate}
-        defaultView="week"
-        availableViews={["week", "day"]}
+        view={calendarLayout}
+        defaultView={calendarLayout}
+        availableViews={["week", "day", "month"]}
         events={events}
         onDateChange={onAnchorDateChange}
-        onViewChange={setCalendarLayout}
+        onViewChange={onCalendarLayoutChange}
         onEventClick={(event) => {
           const booking = event.item as BookingListItem | undefined;
           if (booking) onEventClick(booking);

--- a/src/pages/Facility/Booking/BookingDataPage.tsx
+++ b/src/pages/Facility/Booking/BookingDataPage.tsx
@@ -5,9 +5,9 @@ import {
   type BookingListItem,
 } from "@/api/services/facilityService";
 import type { CalendarView } from "@/components/calendar";
+import PageToolbar from "@/components/common/PageToolbar";
 import type { DataTableColumn, MenuButtonType, PageButtonType } from "@/components/DataPage";
 import { CommonPageButton, CommonRowAction, DataPage } from "@/components/DataPage";
-import PageToolbar from "@/components/common/PageToolbar";
 import { Resource, Verb } from "@/const/enums";
 import { usePermissions } from "@/context/AuthContext";
 import { useModal } from "@/hooks/useModal";

--- a/src/pages/Facility/Booking/BookingDataPage.tsx
+++ b/src/pages/Facility/Booking/BookingDataPage.tsx
@@ -4,6 +4,7 @@ import {
   type BookingDetail,
   type BookingListItem,
 } from "@/api/services/facilityService";
+import type { CalendarView } from "@/components/calendar";
 import type { DataTableColumn, MenuButtonType, PageButtonType } from "@/components/DataPage";
 import { CommonPageButton, CommonRowAction, DataPage } from "@/components/DataPage";
 import PageToolbar from "@/components/common/PageToolbar";
@@ -37,6 +38,13 @@ const parseViewMode = (value: string | null): BookingViewMode => {
   return "list";
 };
 
+const parseCalendarLayout = (value: string | null): CalendarView => {
+  if (value === "day" || value === "month" || value === "week") {
+    return value;
+  }
+  return "week";
+};
+
 const parseIsoDate = (value: string | null): Date => {
   if (!value) return new Date();
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
@@ -57,6 +65,7 @@ const BookingDataPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const viewMode = parseViewMode(searchParams.get("view"));
   const dateParam = searchParams.get("date");
+  const calendarLayout = parseCalendarLayout(searchParams.get("layout"));
   const anchorDate = useMemo(() => parseIsoDate(dateParam), [dateParam]);
 
   const [items, setItems] = useState<BookingRow[]>([]);
@@ -84,8 +93,14 @@ const BookingDataPage = () => {
       const params = new URLSearchParams(searchParams);
       if (next === "list") {
         params.delete("view");
+        params.delete("layout");
       } else {
         params.set("view", next);
+        if (next !== "calendar") {
+          params.delete("layout");
+        } else if (!params.get("layout")) {
+          params.set("layout", calendarLayout);
+        }
       }
       if (date) {
         params.set("date", toIsoDate(date));
@@ -94,7 +109,7 @@ const BookingDataPage = () => {
       }
       setSearchParams(params, { replace: true });
     },
-    [anchorDate, searchParams, setSearchParams]
+    [anchorDate, calendarLayout, searchParams, setSearchParams]
   );
 
   const setAnchorDate = useCallback(
@@ -104,12 +119,31 @@ const BookingDataPage = () => {
       params.set("date", nextDate);
       if (viewMode === "list") {
         params.set("view", "calendar");
+        if (!params.get("layout")) {
+          params.set("layout", "week");
+        }
       } else {
         params.set("view", viewMode);
+        if (viewMode === "calendar" && !params.get("layout")) {
+          params.set("layout", calendarLayout);
+        }
       }
       setSearchParams(params, { replace: true });
     },
-    [searchParams, setSearchParams, viewMode]
+    [calendarLayout, searchParams, setSearchParams, viewMode]
+  );
+
+  const setCalendarLayout = useCallback(
+    (layout: CalendarView) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("view", "calendar");
+      params.set("layout", layout);
+      if (!params.get("date")) {
+        params.set("date", toIsoDate(anchorDate));
+      }
+      setSearchParams(params, { replace: true });
+    },
+    [anchorDate, searchParams, setSearchParams]
   );
 
   const fetchPages = useCallback(async () => {
@@ -349,8 +383,10 @@ const BookingDataPage = () => {
         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
           <BookingCalendar
             anchorDate={anchorDate}
+            calendarLayout={calendarLayout}
             bookings={calendarItems}
             onAnchorDateChange={setAnchorDate}
+            onCalendarLayoutChange={setCalendarLayout}
             onVisibleRangeChange={handleVisibleRangeChange}
             onEventClick={(booking) => void openBookingDetail(booking)}
             onCancelClick={(booking) => {


### PR DESCRIPTION
## Summary

Adds Booking Calendar layout `month` (ADR 0006 / #32): split pane with a compact month grid of booking summaries on the left and Day’s time-axis (K = 10, density overflow → Grid) on the right. Persists Calendar layout in the URL as `layout=week|day|month` with `view=calendar` and `date`.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Month cell summaries: fixed-color dot, start time, Booker; line capacity from measured cell height; `+ N more` sets the anchor only (no remainder popover).
- Adjacent-month padding days are selectable; toolbar month prev/next uses `shiftMonthPreservingDay`.
- Day layout keeps its right-hand mini month; Month embeds Day with `showMiniMonth={false}`.
- Pure helpers + tests in `monthLayout.ts` / `monthLayout.test.ts`.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] Manual: switch to Calendar → Month; click summaries / `+ N more` / padding days; confirm URL `layout=month`; overflow → Grid

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Closes #32