### PR TITLE
feat: add Room gallery picker, preview, and ordered fileIds save

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -115,6 +115,7 @@ export const API_ENDPOINTS = {
       SUMMARY: `${ADMIN_API_PREFIX}/content/file/summary`,
       UPLOAD: `${ADMIN_API_PREFIX}/content/file/upload`,
       BULK_DELETE: `${ADMIN_API_PREFIX}/content/file/bulk`,
+      ASSOCIATION_PREVIEW: `${ADMIN_API_PREFIX}/content/file/association-preview`,
     },
   },
 

--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -62,6 +62,12 @@ export interface RoomDetail extends RoomListItem {
   deleteReason?: string;
   description?: string;
   translations?: FacilityTranslationItem[];
+  files?: {
+    id: string;
+    originalName: string;
+    url?: string;
+    sizeBytes?: number;
+  }[];
 }
 
 export interface RoomWrite {
@@ -71,6 +77,7 @@ export interface RoomWrite {
   isActive?: boolean;
   sequence?: number;
   translations?: FacilityTranslationInput[];
+  fileIds?: string[];
 }
 
 export interface RoomCreate extends RoomWrite {

--- a/src/api/services/fileService.ts
+++ b/src/api/services/fileService.ts
@@ -2,6 +2,7 @@ import { API_ENDPOINTS, httpClient } from "@/api";
 import type {
   BulkDeleteRequest,
   BulkDeleteResponse,
+  FileAssociationPreviewResponse,
   FilePagesParams,
   FilePagesResponse,
   FileSummaryResponse,
@@ -40,6 +41,10 @@ export const fileService = {
         }
       },
     });
+  },
+
+  async previewAssociations(payload: BulkDeleteRequest) {
+    return httpClient.post<FileAssociationPreviewResponse>(API_ENDPOINTS.CONTENT.FILES.ASSOCIATION_PREVIEW, payload);
   },
 
   async bulkDelete(payload: BulkDeleteRequest) {

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -86,6 +86,10 @@
     },
     "preview": {
       "title": "Image Preview"
+    },
+    "picker": {
+      "title": "Choose images",
+      "confirm": "Confirm ({{count}})"
     }
   }
 }

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -89,7 +89,9 @@
     },
     "picker": {
       "title": "Choose images",
-      "confirm": "Confirm ({{count}})"
+      "confirm": "Confirm ({{count}})",
+      "upload": "Upload",
+      "uploadTitle": "Upload images"
     }
   }
 }

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -80,9 +80,14 @@
     "delete": {
       "title": "Confirm Delete",
       "confirmMessage": "Delete {{count}} selected file(s)? This action cannot be undone.",
+      "associationWarning": "These files will be removed from every bound resource, including deleted rooms.",
+      "loadingAssociations": "Loading bound resources…",
+      "noAssociations": "No bound resources.",
+      "deletedResource": "(deleted)",
       "submit": "Delete",
       "submitting": "Deleting...",
-      "failed": "Failed to delete files"
+      "failed": "Failed to delete files",
+      "previewFailed": "Failed to load file associations"
     },
     "preview": {
       "title": "Image Preview"

--- a/src/i18n/locales/en/facility.json
+++ b/src/i18n/locales/en/facility.json
@@ -42,7 +42,13 @@
       "capacityHint": "Optional. Leave blank if capacity is not specified.",
       "description": "Description",
       "codeRequired": "Code is required",
-      "nameRequired": "Name is required"
+      "nameRequired": "Name is required",
+      "gallery": "Gallery",
+      "galleryHint": "Optional. Up to {{max}} unique images. Drag to reorder.",
+      "galleryPick": "Choose images",
+      "gallerySelected": "{{count}} of {{max}} images",
+      "galleryMax": "A room gallery can include at most {{max}} images.",
+      "galleryDuplicate": "Each image can appear only once in this gallery."
     },
     "deleteForm": {
       "entityLabel": "room"

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -89,7 +89,9 @@
     },
     "picker": {
       "title": "选择图片",
-      "confirm": "确认选择（{{count}}）"
+      "confirm": "确认选择（{{count}}）",
+      "upload": "上传",
+      "uploadTitle": "上传图片"
     }
   }
 }

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -80,9 +80,14 @@
     "delete": {
       "title": "确认删除",
       "confirmMessage": "确定要删除所选的 {{count}} 个文件吗？此操作无法撤销。",
+      "associationWarning": "这些文件会从所有已绑定资源移除，包含已删除的房间。",
+      "loadingAssociations": "正在加载绑定资源…",
+      "noAssociations": "没有绑定资源。",
+      "deletedResource": "（已删除）",
       "submit": "删除",
       "submitting": "删除中...",
-      "failed": "删除文件失败"
+      "failed": "删除文件失败",
+      "previewFailed": "无法加载文件关联"
     },
     "preview": {
       "title": "图片预览"

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -86,6 +86,10 @@
     },
     "preview": {
       "title": "图片预览"
+    },
+    "picker": {
+      "title": "选择图片",
+      "confirm": "确认选择（{{count}}）"
     }
   }
 }

--- a/src/i18n/locales/zh-CN/facility.json
+++ b/src/i18n/locales/zh-CN/facility.json
@@ -42,7 +42,13 @@
       "capacityHint": "选填。未标明容量时可留空。",
       "description": "說明",
       "codeRequired": "請輸入代碼",
-      "nameRequired": "請輸入名稱"
+      "nameRequired": "請輸入名稱",
+      "gallery": "相册",
+      "galleryHint": "选填。最多 {{max}} 张不重复图片，可拖曳排序。",
+      "galleryPick": "选择图片",
+      "gallerySelected": "{{count}} / {{max}} 张图片",
+      "galleryMax": "场地相册最多只能有 {{max}} 张图片。",
+      "galleryDuplicate": "同一张图片在此相册中只能出现一次。"
     },
     "deleteForm": {
       "entityLabel": "場地"

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -86,6 +86,10 @@
     },
     "preview": {
       "title": "圖片預覽"
+    },
+    "picker": {
+      "title": "選擇圖片",
+      "confirm": "確認選擇（{{count}}）"
     }
   }
 }

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -80,9 +80,14 @@
     "delete": {
       "title": "確認刪除",
       "confirmMessage": "確定要刪除所選的 {{count}} 個檔案嗎？此操作無法復原。",
+      "associationWarning": "這些檔案會從所有已綁定資源移除，包含已刪除的房間。",
+      "loadingAssociations": "正在載入綁定資源…",
+      "noAssociations": "沒有綁定資源。",
+      "deletedResource": "（已刪除）",
       "submit": "刪除",
       "submitting": "刪除中...",
-      "failed": "刪除檔案失敗"
+      "failed": "刪除檔案失敗",
+      "previewFailed": "無法載入檔案關聯"
     },
     "preview": {
       "title": "圖片預覽"

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -89,7 +89,9 @@
     },
     "picker": {
       "title": "選擇圖片",
-      "confirm": "確認選擇（{{count}}）"
+      "confirm": "確認選擇（{{count}}）",
+      "upload": "上傳",
+      "uploadTitle": "上傳圖片"
     }
   }
 }

--- a/src/i18n/locales/zh-TW/facility.json
+++ b/src/i18n/locales/zh-TW/facility.json
@@ -42,7 +42,13 @@
       "capacityHint": "選填。未標示容量時可留空。",
       "description": "說明",
       "codeRequired": "請輸入代碼",
-      "nameRequired": "請輸入名稱"
+      "nameRequired": "請輸入名稱",
+      "gallery": "相簿",
+      "galleryHint": "選填。最多 {{max}} 張不重複圖片，可拖曳排序。",
+      "galleryPick": "選擇圖片",
+      "gallerySelected": "{{count}} / {{max}} 張圖片",
+      "galleryMax": "場地相簿最多只能有 {{max}} 張圖片。",
+      "galleryDuplicate": "同一張圖片在此相簿中只能出現一次。"
     },
     "deleteForm": {
       "entityLabel": "場地"

--- a/src/pages/Content/File/FileDataPage.tsx
+++ b/src/pages/Content/File/FileDataPage.tsx
@@ -16,7 +16,8 @@ import FileTableList from "./FileTableList";
 import FileUploadForm, { type FileUploadFormHandle } from "./FileUploadForm";
 import MediaCategoryCards from "./MediaCategoryCards";
 import StorageDetailsCard from "./StorageDetailsCard";
-import type { FileItem, FileSummaryResponse, MediaCategory, SortOrder } from "./types";
+import { groupFileAssociationPreview } from "./fileAssociationPreview";
+import type { FileDeleteAssociationGroup, FileItem, FileSummaryResponse, MediaCategory, SortOrder } from "./types";
 import {
   convertFileGridItemToFileItem,
   convertSortOrderToApiParams,
@@ -40,6 +41,9 @@ const FileDataPage = () => {
   const [totalEntries, setTotalEntries] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [deleteIds, setDeleteIds] = useState<string[]>([]);
+  const [deleteGroups, setDeleteGroups] = useState<FileDeleteAssociationGroup[]>([]);
   const [allowMixedUpload, setAllowMixedUpload] = useState(false);
 
   const { isOpen: isUploadModalOpen, openModal: openUploadModal, closeModal: closeUploadModal } = useModal();
@@ -155,22 +159,57 @@ const FileDataPage = () => {
     });
   }, [files, isAllSelected]);
 
+  const fileNames = useMemo(() => {
+    const names: Record<string, string> = {};
+    files.forEach((file) => {
+      names[file.id] = file.name;
+    });
+    return names;
+  }, [files]);
+
+  const loadDeletePreview = useCallback(
+    async (ids: string[]) => {
+      if (ids.length === 0) {
+        return;
+      }
+      setDeleteIds(ids);
+      setDeleteGroups(groupFileAssociationPreview(ids, []));
+      setLoadingPreview(true);
+      openDeleteModal();
+      try {
+        const response = await fileService.previewAssociations({ ids });
+        if (!response.success) {
+          throw new Error(response.message || t("file.delete.previewFailed"));
+        }
+        setDeleteGroups(groupFileAssociationPreview(ids, response.data.items || []));
+      } catch (error) {
+        notifyApiError(error, {
+          title: t("file.delete.previewFailed"),
+          fallbackDescription: t("file.delete.previewFailed"),
+        });
+        closeDeleteModal();
+      } finally {
+        setLoadingPreview(false);
+      }
+    },
+    [closeDeleteModal, openDeleteModal, t]
+  );
+
   const handleBatchDelete = useCallback(() => {
-    if (selectedKeys.length === 0) {
-      return;
-    }
-    openDeleteModal();
-  }, [openDeleteModal, selectedKeys.length]);
+    void loadDeletePreview(selectedKeys);
+  }, [loadDeletePreview, selectedKeys]);
 
   const handleDeleteConfirm = useCallback(async () => {
-    if (selectedKeys.length === 0) {
+    if (deleteIds.length === 0 || loadingPreview) {
       return;
     }
     try {
       setDeleting(true);
-      const response = await fileService.bulkDelete({ ids: selectedKeys });
+      const response = await fileService.bulkDelete({ ids: deleteIds });
       if (response.success) {
         setSelectedKeys([]);
+        setDeleteIds([]);
+        setDeleteGroups([]);
         notifySuccess({ title: t("common:feedback.deleted") });
         closeDeleteModal();
         await refreshAll();
@@ -183,14 +222,14 @@ const FileDataPage = () => {
     } finally {
       setDeleting(false);
     }
-  }, [closeDeleteModal, refreshAll, selectedKeys, t]);
+  }, [closeDeleteModal, deleteIds, loadingPreview, refreshAll, t]);
 
   const handleDeleteOne = useCallback(
     (fileId: string) => {
       setSelectedKeys([fileId]);
-      openDeleteModal();
+      void loadDeletePreview([fileId]);
     },
-    [openDeleteModal]
+    [loadDeletePreview]
   );
 
   const handleCloseUploadModal = useCallback(async () => {
@@ -428,7 +467,10 @@ const FileDataPage = () => {
         className="mx-4 w-full max-w-[560px] p-6"
       >
         <FileDeleteForm
-          fileCount={selectedKeys.length}
+          fileCount={deleteIds.length}
+          fileNames={fileNames}
+          groups={deleteGroups}
+          loadingPreview={loadingPreview}
           onSubmit={handleDeleteConfirm}
           onCancel={closeDeleteModal}
           submitting={deleting}

--- a/src/pages/Content/File/FileDeleteForm.tsx
+++ b/src/pages/Content/File/FileDeleteForm.tsx
@@ -1,26 +1,63 @@
 import { Button } from "@efcnewlife/newlife-ui";
 import { useTranslation } from "react-i18next";
+import type { FileDeleteAssociationGroup } from "./types";
 
 interface FileDeleteFormProps {
   fileCount: number;
+  fileNames: Record<string, string>;
+  groups: FileDeleteAssociationGroup[];
+  loadingPreview?: boolean;
   onSubmit: () => void;
   onCancel: () => void;
   submitting?: boolean;
 }
 
-const FileDeleteForm = ({ fileCount, onSubmit, onCancel, submitting = false }: FileDeleteFormProps) => {
+const FileDeleteForm = ({
+  fileCount,
+  fileNames,
+  groups,
+  loadingPreview = false,
+  onSubmit,
+  onCancel,
+  submitting = false,
+}: FileDeleteFormProps) => {
   const { t } = useTranslation("content");
+  const confirmDisabled = submitting || loadingPreview;
 
   return (
     <div className="space-y-6">
       <p className="text-sm text-gray-600 dark:text-gray-300">
         {t("file.delete.confirmMessage", { count: fileCount })}
       </p>
+      <p className="text-sm text-gray-600 dark:text-gray-300">{t("file.delete.associationWarning")}</p>
+      {loadingPreview ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">{t("file.delete.loadingAssociations")}</p>
+      ) : (
+        <ul className="max-h-64 space-y-3 overflow-y-auto text-sm">
+          {groups.map((group) => (
+            <li key={group.fileId}>
+              <p className="font-medium text-gray-900 dark:text-white/90">{fileNames[group.fileId] ?? group.fileId}</p>
+              {group.bindings.length === 0 ? (
+                <p className="mt-1 text-gray-500 dark:text-gray-400">{t("file.delete.noAssociations")}</p>
+              ) : (
+                <ul className="mt-1 list-disc space-y-1 pl-5 text-gray-600 dark:text-gray-300">
+                  {group.bindings.map((binding) => (
+                    <li key={`${binding.resourceKind}-${binding.resourceId}`}>
+                      {binding.displayName}
+                      {binding.isDeleted ? ` ${t("file.delete.deletedResource")}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
       <div className="flex justify-end gap-3">
         <Button variant="outline" size="sm" onClick={onCancel} disabled={submitting}>
           {t("common:cancel")}
         </Button>
-        <Button variant="primary" size="sm" onClick={onSubmit} disabled={submitting}>
+        <Button variant="primary" size="sm" onClick={onSubmit} disabled={confirmDisabled}>
           {submitting ? t("file.delete.submitting") : t("file.delete.submit")}
         </Button>
       </div>

--- a/src/pages/Content/File/FileSelectionModal.tsx
+++ b/src/pages/Content/File/FileSelectionModal.tsx
@@ -9,9 +9,11 @@ import { notifyApiError } from "@/utils/operationFeedback";
 import { Button, Modal, Select } from "@efcnewlife/newlife-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MdUpload } from "react-icons/md";
 import FileGrid from "./FileGrid";
+import FileUploadForm, { type FileUploadFormHandle } from "./FileUploadForm";
 import type { FileItem, SortOrder } from "./types";
-import { convertFileGridItemToFileItem, convertSortOrderToApiParams } from "./utils";
+import { appendUploadedFiles, convertFileGridItemToFileItem, convertSortOrderToApiParams } from "./utils";
 
 const PAGE_SIZE_OPTIONS = [25, 50, 75, 100];
 
@@ -40,12 +42,16 @@ const FileSelectionModal = ({
   const [loading, setLoading] = useState(false);
   const [files, setFiles] = useState<FileItem[]>([]);
   const [totalEntries, setTotalEntries] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [isUploadOpen, setIsUploadOpen] = useState(false);
   const fileCacheRef = useRef<Map<string, FileItem>>(new Map());
+  const fileUploadFormRef = useRef<FileUploadFormHandle>(null);
 
   const sortParams = useMemo(() => convertSortOrderToApiParams(sortOrder), [sortOrder]);
 
   useEffect(() => {
     if (!isOpen) {
+      setIsUploadOpen(false);
       return;
     }
     const initialIds = initialSelectedItems.map((item) => item.id);
@@ -114,6 +120,76 @@ const FileSelectionModal = ({
     [maxSelected, onMaxReached]
   );
 
+  const selectedItemsFromKeys = useCallback((keys: string[]): FileItem[] => {
+    return keys.map((id) => fileCacheRef.current.get(id)).filter((item): item is FileItem => Boolean(item));
+  }, []);
+
+  const handleCloseUpload = useCallback(() => {
+    setIsUploadOpen(false);
+    fileUploadFormRef.current?.clearFiles();
+  }, []);
+
+  const handleFileUpload = useCallback(async () => {
+    if (!fileUploadFormRef.current?.validate()) {
+      return;
+    }
+    const uploadFiles = fileUploadFormRef.current.getFiles();
+    if (uploadFiles.length === 0) {
+      return;
+    }
+    try {
+      setUploading(true);
+      const uploadedItems: FileItem[] = [];
+      for (let index = 0; index < uploadFiles.length; index += 1) {
+        const file = uploadFiles[index];
+        fileUploadFormRef.current?.setUploadStatus(index, "uploading");
+        try {
+          const response = await fileService.uploadOne(file, "images", (progress) => {
+            fileUploadFormRef.current?.setUploadProgress(index, progress);
+          });
+          if (response.success && response.data?.id) {
+            const duplicate = response.data.duplicate === true;
+            const message = duplicate ? t("file.upload.duplicateExisting") : t("file.upload.success");
+            fileUploadFormRef.current?.setUploadStatus(index, "success", undefined, message);
+            uploadedItems.push({
+              id: response.data.id,
+              url: "",
+              name: file.name,
+              size: file.size,
+              contentType: file.type,
+            });
+          } else {
+            fileUploadFormRef.current?.setUploadStatus(index, "error", response.message || t("file.upload.error"));
+          }
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : t("file.upload.error");
+          fileUploadFormRef.current?.setUploadStatus(index, "error", message);
+        }
+      }
+      uploadedItems.forEach((item) => {
+        const cached = fileCacheRef.current.get(item.id);
+        if (!cached) {
+          fileCacheRef.current.set(item.id, item);
+        }
+      });
+      await fetchPages();
+      setSelectedKeys((prev) => {
+        const mergedUploads = uploadedItems.map((item) => fileCacheRef.current.get(item.id) ?? item);
+        const result = appendUploadedFiles(selectedItemsFromKeys(prev), mergedUploads, maxSelected);
+        if (result.overCap) {
+          onMaxReached?.();
+        }
+        result.items.forEach((item) => {
+          fileCacheRef.current.set(item.id, item);
+        });
+        return result.items.map((item) => item.id);
+      });
+      handleCloseUpload();
+    } finally {
+      setUploading(false);
+    }
+  }, [fetchPages, handleCloseUpload, maxSelected, onMaxReached, selectedItemsFromKeys, t]);
+
   const sortOptions = useMemo(
     () => [
       { value: "date_desc", label: t("file.sort.dateDesc") },
@@ -128,6 +204,16 @@ const FileSelectionModal = ({
 
   const toolbarButtons: PageButtonType[] = useMemo(
     () => [
+      {
+        key: "upload",
+        text: t("file.picker.upload"),
+        icon: <MdUpload className="size-4" />,
+        align: "left",
+        variant: "primary",
+        size: "md",
+        onClick: () => setIsUploadOpen(true),
+        permission: Verb.Create,
+      },
       CommonPageButton.REFRESH(() => {
         void fetchPages();
       }),
@@ -164,26 +250,30 @@ const FileSelectionModal = ({
   );
 
   const handleConfirm = useCallback(() => {
-    const selectedFiles = selectedKeys
-      .map((id) => fileCacheRef.current.get(id))
-      .filter((item): item is FileItem => Boolean(item));
+    const selectedFiles = selectedItemsFromKeys(selectedKeys);
     onConfirm(selectedFiles);
     onClose();
-  }, [onClose, onConfirm, selectedKeys]);
+  }, [onClose, onConfirm, selectedItemsFromKeys, selectedKeys]);
 
   return (
     <Modal
-      title={t("file.picker.title")}
+      title={isUploadOpen ? t("file.picker.uploadTitle") : t("file.picker.title")}
       isOpen={isOpen}
       onClose={onClose}
       className="mx-4 flex max-h-[90vh] w-full max-w-[90vw] flex-col bg-white p-6 dark:bg-gray-900"
     >
       <div className="flex min-h-0 max-h-[calc(90vh-120px)] flex-1 flex-col">
-        <div className="shrink-0">
-          <DataTableToolbar buttons={toolbarButtons} resource={Resource.ContentFile} />
-        </div>
+        {!isUploadOpen && (
+          <div className="shrink-0">
+            <DataTableToolbar buttons={toolbarButtons} resource={Resource.ContentFile} />
+          </div>
+        )}
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          {loading ? (
+          {isUploadOpen ? (
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <FileUploadForm ref={fileUploadFormRef} mediaCategory="images" />
+            </div>
+          ) : loading ? (
             <div className="flex h-[400px] items-center justify-center">
               <LoadingSpinner />
             </div>
@@ -197,25 +287,38 @@ const FileSelectionModal = ({
                   currentPage={currentPage}
                   totalPages={totalPages}
                   rowsPerPage={itemsPerPage}
-                  totalEntries={totalEntries}
-                  pageSizeOptions={PAGE_SIZE_OPTIONS}
                   onPageChange={setCurrentPage}
                   onRowsPerPageChange={(size) => {
                     setItemsPerPage(size);
                     setCurrentPage(1);
                   }}
+                  totalEntries={totalEntries}
+                  pageSizeOptions={PAGE_SIZE_OPTIONS}
                 />
               </div>
             </>
           )}
         </div>
         <div className="mt-4 flex shrink-0 justify-end gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
-          <Button variant="outline" onClick={onClose}>
-            {t("common:cancel")}
-          </Button>
-          <Button variant="primary" onClick={handleConfirm}>
-            {t("file.picker.confirm", { count: selectedKeys.length })}
-          </Button>
+          {isUploadOpen ? (
+            <>
+              <Button variant="outline" onClick={handleCloseUpload} disabled={uploading}>
+                {t("file.upload.close")}
+              </Button>
+              <Button variant="primary" onClick={() => void handleFileUpload()} disabled={uploading}>
+                {uploading ? t("file.upload.submitting") : t("file.upload.submit")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={onClose}>
+                {t("common:cancel")}
+              </Button>
+              <Button variant="primary" onClick={handleConfirm}>
+                {t("file.picker.confirm", { count: selectedKeys.length })}
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/pages/Content/File/FileSelectionModal.tsx
+++ b/src/pages/Content/File/FileSelectionModal.tsx
@@ -1,0 +1,225 @@
+import fileService from "@/api/services/fileService";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import DataTableFooter from "@/components/DataPage/DataTableFooter";
+import DataTableToolbar from "@/components/DataPage/DataTableToolbar";
+import { CommonPageButton } from "@/components/DataPage/PageButtonTypes";
+import type { PageButtonType } from "@/components/DataPage/types";
+import { Resource, Verb } from "@/const/enums";
+import { notifyApiError } from "@/utils/operationFeedback";
+import { Button, Modal, Select } from "@efcnewlife/newlife-ui";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import FileGrid from "./FileGrid";
+import type { FileItem, SortOrder } from "./types";
+import { convertFileGridItemToFileItem, convertSortOrderToApiParams } from "./utils";
+
+const PAGE_SIZE_OPTIONS = [25, 50, 75, 100];
+
+export interface FileSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (selectedFiles: FileItem[]) => void;
+  initialSelectedItems?: FileItem[];
+  maxSelected: number;
+  onMaxReached?: () => void;
+}
+
+const FileSelectionModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  initialSelectedItems = [],
+  maxSelected,
+  onMaxReached,
+}: FileSelectionModalProps) => {
+  const { t } = useTranslation("content");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(25);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [sortOrder, setSortOrder] = useState<SortOrder>("date_desc");
+  const [loading, setLoading] = useState(false);
+  const [files, setFiles] = useState<FileItem[]>([]);
+  const [totalEntries, setTotalEntries] = useState(0);
+  const fileCacheRef = useRef<Map<string, FileItem>>(new Map());
+
+  const sortParams = useMemo(() => convertSortOrderToApiParams(sortOrder), [sortOrder]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const initialIds = initialSelectedItems.map((item) => item.id);
+    setSelectedKeys(initialIds);
+    initialSelectedItems.forEach((item) => {
+      fileCacheRef.current.set(item.id, item);
+    });
+    setCurrentPage(1);
+  }, [isOpen, initialSelectedItems]);
+
+  const fetchPages = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fileService.getPages({
+        page: currentPage - 1,
+        page_size: itemsPerPage,
+        media_category: "images",
+        ...sortParams,
+      });
+      if (response.success) {
+        const items = (response.data.items || []).map(convertFileGridItemToFileItem);
+        items.forEach((item) => {
+          fileCacheRef.current.set(item.id, item);
+        });
+        setFiles(items);
+        setTotalEntries(response.data.total);
+      } else {
+        setFiles([]);
+        setTotalEntries(0);
+      }
+    } catch (error) {
+      notifyApiError(error, {
+        title: t("common:feedback.loadFailed"),
+        fallbackDescription: t("common:feedback.loadFailedDesc"),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [currentPage, itemsPerPage, sortParams, t]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    void fetchPages();
+  }, [fetchPages, isOpen]);
+
+  const totalPages = totalEntries > 0 ? Math.ceil(totalEntries / itemsPerPage) : 0;
+
+  const handleFileSelect = useCallback(
+    (fileId: string, checked: boolean) => {
+      setSelectedKeys((prev) => {
+        if (checked) {
+          if (prev.includes(fileId)) {
+            return prev;
+          }
+          if (prev.length >= maxSelected) {
+            onMaxReached?.();
+            return prev;
+          }
+          return [...prev, fileId];
+        }
+        return prev.filter((id) => id !== fileId);
+      });
+    },
+    [maxSelected, onMaxReached]
+  );
+
+  const sortOptions = useMemo(
+    () => [
+      { value: "date_desc", label: t("file.sort.dateDesc") },
+      { value: "date_asc", label: t("file.sort.dateAsc") },
+      { value: "name_asc", label: t("file.sort.nameAsc") },
+      { value: "name_desc", label: t("file.sort.nameDesc") },
+      { value: "size_desc", label: t("file.sort.sizeDesc") },
+      { value: "size_asc", label: t("file.sort.sizeAsc") },
+    ],
+    [t]
+  );
+
+  const toolbarButtons: PageButtonType[] = useMemo(
+    () => [
+      CommonPageButton.REFRESH(() => {
+        void fetchPages();
+      }),
+      {
+        key: "sort",
+        text: t("file.toolbar.sort"),
+        align: "right",
+        size: "md",
+        onClick: () => {},
+        render: () => (
+          <div className="flex items-center gap-2">
+            <label className="whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
+              {t("file.toolbar.sort")}
+            </label>
+            <Select
+              id="room-gallery-file-sort"
+              options={sortOptions}
+              value={sortOrder}
+              onChange={(value) => {
+                setSortOrder(value as SortOrder);
+                setCurrentPage(1);
+              }}
+              placeholder={t("file.toolbar.sortPlaceholder")}
+              size="sm"
+              variant="ghost"
+              className="w-48"
+            />
+          </div>
+        ),
+        permission: Verb.Read,
+      },
+    ],
+    [fetchPages, sortOptions, sortOrder, t]
+  );
+
+  const handleConfirm = useCallback(() => {
+    const selectedFiles = selectedKeys
+      .map((id) => fileCacheRef.current.get(id))
+      .filter((item): item is FileItem => Boolean(item));
+    onConfirm(selectedFiles);
+    onClose();
+  }, [onClose, onConfirm, selectedKeys]);
+
+  return (
+    <Modal
+      title={t("file.picker.title")}
+      isOpen={isOpen}
+      onClose={onClose}
+      className="mx-4 flex max-h-[90vh] w-full max-w-[90vw] flex-col bg-white p-6 dark:bg-gray-900"
+    >
+      <div className="flex min-h-0 max-h-[calc(90vh-120px)] flex-1 flex-col">
+        <div className="shrink-0">
+          <DataTableToolbar buttons={toolbarButtons} resource={Resource.ContentFile} />
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {loading ? (
+            <div className="flex h-[400px] items-center justify-center">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            <>
+              <div className="min-h-0 flex-1 overflow-y-auto border-x border-b border-gray-100 bg-white dark:border-white/[0.05] dark:bg-gray-900">
+                <FileGrid files={files} selectedKeys={selectedKeys} onSelect={handleFileSelect} />
+              </div>
+              <div className="shrink-0">
+                <DataTableFooter
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  rowsPerPage={itemsPerPage}
+                  totalEntries={totalEntries}
+                  pageSizeOptions={PAGE_SIZE_OPTIONS}
+                  onPageChange={setCurrentPage}
+                  onRowsPerPageChange={(size) => {
+                    setItemsPerPage(size);
+                    setCurrentPage(1);
+                  }}
+                />
+              </div>
+            </>
+          )}
+        </div>
+        <div className="mt-4 flex shrink-0 justify-end gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
+          <Button variant="outline" onClick={onClose}>
+            {t("common:cancel")}
+          </Button>
+          <Button variant="primary" onClick={handleConfirm}>
+            {t("file.picker.confirm", { count: selectedKeys.length })}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default FileSelectionModal;

--- a/src/pages/Content/File/fileAssociationPreview.test.ts
+++ b/src/pages/Content/File/fileAssociationPreview.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { FileAssociationPreviewItem } from "./types";
+import { groupFileAssociationPreview } from "./fileAssociationPreview";
+
+const binding = (
+  overrides: Partial<FileAssociationPreviewItem> & Pick<FileAssociationPreviewItem, "fileId">
+): FileAssociationPreviewItem => ({
+  resourceKind: "facility.room",
+  resourceId: "room-1",
+  displayName: "Sanctuary",
+  isDeleted: false,
+  ...overrides,
+});
+
+describe("groupFileAssociationPreview", () => {
+  it("keeps every selected file in order, including files with no bindings", () => {
+    const items = [binding({ fileId: "file-b", displayName: "Hall A" })];
+    const groups = groupFileAssociationPreview(["file-a", "file-b"], items);
+
+    expect(groups.map((group) => group.fileId)).toEqual(["file-a", "file-b"]);
+    expect(groups[0].bindings).toEqual([]);
+    expect(groups[1].bindings.map((row) => row.displayName)).toEqual(["Hall A"]);
+  });
+
+  it("lists named bindings and marks soft-deleted rooms", () => {
+    const items = [
+      binding({ fileId: "file-1", resourceId: "room-live", displayName: "Sanctuary", isDeleted: false }),
+      binding({ fileId: "file-1", resourceId: "room-gone", displayName: "OLD-HALL", isDeleted: true }),
+    ];
+    const groups = groupFileAssociationPreview(["file-1"], items);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].bindings).toEqual([
+      {
+        fileId: "file-1",
+        resourceKind: "facility.room",
+        resourceId: "room-live",
+        displayName: "Sanctuary",
+        isDeleted: false,
+      },
+      {
+        fileId: "file-1",
+        resourceKind: "facility.room",
+        resourceId: "room-gone",
+        displayName: "OLD-HALL",
+        isDeleted: true,
+      },
+    ]);
+  });
+
+  it("ignores bindings for files that are not selected", () => {
+    const items = [binding({ fileId: "other", displayName: "Ignored" })];
+    const groups = groupFileAssociationPreview(["file-1"], items);
+
+    expect(groups).toEqual([{ fileId: "file-1", bindings: [] }]);
+  });
+});

--- a/src/pages/Content/File/fileAssociationPreview.ts
+++ b/src/pages/Content/File/fileAssociationPreview.ts
@@ -1,0 +1,24 @@
+import type { FileAssociationPreviewItem, FileDeleteAssociationGroup } from "./types";
+
+export const groupFileAssociationPreview = (
+  selectedIds: string[],
+  items: FileAssociationPreviewItem[]
+): FileDeleteAssociationGroup[] => {
+  const bindingsByFileId = new Map<string, FileAssociationPreviewItem[]>();
+  selectedIds.forEach((fileId) => {
+    bindingsByFileId.set(fileId, []);
+  });
+
+  items.forEach((item) => {
+    const bindings = bindingsByFileId.get(item.fileId);
+    if (!bindings) {
+      return;
+    }
+    bindings.push(item);
+  });
+
+  return selectedIds.map((fileId) => ({
+    fileId,
+    bindings: bindingsByFileId.get(fileId) ?? [],
+  }));
+};

--- a/src/pages/Content/File/types.ts
+++ b/src/pages/Content/File/types.ts
@@ -58,6 +58,23 @@ export interface BulkDeleteResponse {
   failedItems?: FileBase[] | null;
 }
 
+export interface FileAssociationPreviewItem {
+  fileId: string;
+  resourceKind: string;
+  resourceId: string;
+  displayName: string;
+  isDeleted: boolean;
+}
+
+export interface FileAssociationPreviewResponse {
+  items: FileAssociationPreviewItem[];
+}
+
+export interface FileDeleteAssociationGroup {
+  fileId: string;
+  bindings: FileAssociationPreviewItem[];
+}
+
 export type SortOrder = "name_asc" | "name_desc" | "date_asc" | "date_desc" | "size_asc" | "size_desc";
 
 export interface FilePagesParams extends Record<string, unknown> {

--- a/src/pages/Content/File/utils.ts
+++ b/src/pages/Content/File/utils.ts
@@ -92,6 +92,30 @@ export const convertFileGridItemToFileItem = (item: FileGridItem): FileItem => {
   };
 };
 
+export const appendUploadedFiles = (
+  current: FileItem[],
+  uploaded: FileItem[],
+  max: number
+): { items: FileItem[]; overCap: boolean } => {
+  const currentIds = new Set(current.map((item) => item.id));
+  const seenUpload = new Set<string>();
+  const appended: FileItem[] = [];
+  let overCap = false;
+  for (const item of uploaded) {
+    if (seenUpload.has(item.id) || currentIds.has(item.id)) {
+      continue;
+    }
+    seenUpload.add(item.id);
+    if (current.length + appended.length >= max) {
+      overCap = true;
+      continue;
+    }
+    appended.push(item);
+    currentIds.add(item.id);
+  }
+  return { items: [...current, ...appended], overCap };
+};
+
 export const getCategorySharePercent = (sizeBytes: number, totalBytes: number): number => {
   if (totalBytes <= 0) return 0;
   return Math.round((sizeBytes / totalBytes) * 100);

--- a/src/pages/Facility/Room/RoomDataForm.tsx
+++ b/src/pages/Facility/Room/RoomDataForm.tsx
@@ -1,6 +1,11 @@
 import type { FacilityTranslationItem } from "@/api/services/facilityService";
 import TranslationTabsForm from "@/components/translation/TranslationTabsForm";
 import { useActiveLocales } from "@/hooks/useActiveLocales";
+import { useModal } from "@/hooks/useModal";
+import FileSelectionModal from "@/pages/Content/File/FileSelectionModal";
+import ImagePreviewCard from "@/pages/Content/File/ImagePreviewCard";
+import type { FileItem } from "@/pages/Content/File/types";
+import { cn } from "@/utils";
 import {
   buildTranslationPayload,
   createEmptyTranslationMap,
@@ -8,9 +13,19 @@ import {
   validateDefaultLocaleName,
   type TranslationMap,
 } from "@/utils/translationForm";
-import { Checkbox, Input } from "@efcnewlife/newlife-ui";
+import { Button, Checkbox, FormField, Input } from "@efcnewlife/newlife-ui";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MdAdd } from "react-icons/md";
+import {
+  ROOM_GALLERY_MAX_FILES,
+  applyPickerSelection,
+  galleryFileIds,
+  hydrateGalleryFromFiles,
+  reorderGallery,
+  validateGallery,
+  type RoomGalleryFile,
+} from "./roomGallery";
 
 export interface RoomFormValues {
   code: string;
@@ -20,6 +35,8 @@ export interface RoomFormValues {
   isActive?: boolean;
   description?: string;
   translations?: FacilityTranslationItem[];
+  files?: RoomGalleryFile[];
+  fileIds?: string[];
 }
 
 export interface RoomDataFormHandle {
@@ -42,7 +59,10 @@ const RoomDataForm = forwardRef<
   );
   const [isActive, setIsActive] = useState(defaultValues?.isActive ?? true);
   const [translationMap, setTranslationMap] = useState<TranslationMap>({});
-  const [errors, setErrors] = useState<{ code?: string; name?: string }>({});
+  const [galleryItems, setGalleryItems] = useState<FileItem[]>([]);
+  const [dragFromIndex, setDragFromIndex] = useState<number | null>(null);
+  const [errors, setErrors] = useState<{ code?: string; name?: string; gallery?: string }>({});
+  const { isOpen: isPickerOpen, openModal: openPicker, closeModal: closePicker } = useModal(false);
 
   useEffect(() => {
     if (locales.length === 0) return;
@@ -50,6 +70,7 @@ const RoomDataForm = forwardRef<
     setRoomNumber(defaultValues?.roomNumber || "");
     setCapacity(defaultValues?.capacity !== undefined ? String(defaultValues.capacity) : "");
     setIsActive(defaultValues?.isActive ?? true);
+    setGalleryItems(hydrateGalleryFromFiles(defaultValues?.files));
     setTranslationMap(
       hydrateTranslationMap(locales, defaultValues?.translations, {
         name: defaultValues?.name,
@@ -64,11 +85,19 @@ const RoomDataForm = forwardRef<
     }
   }, [locales, translationMap]);
 
+  const galleryErrorMessage = (error: ReturnType<typeof validateGallery>): string | undefined => {
+    if (error === "max") return t("room.form.galleryMax", { max: ROOM_GALLERY_MAX_FILES });
+    if (error === "duplicate") return t("room.form.galleryDuplicate");
+    return undefined;
+  };
+
   const validate = (): boolean => {
-    const next: { code?: string; name?: string } = {};
+    const next: { code?: string; name?: string; gallery?: string } = {};
     if (mode === "create" && !code.trim()) next.code = t("room.form.codeRequired");
     const name_error_key = validateDefaultLocaleName(translationMap, defaultLocaleId);
     if (name_error_key) next.name = tCommon(name_error_key);
+    const galleryError = validateGallery(galleryItems);
+    if (galleryError) next.gallery = galleryErrorMessage(galleryError);
     setErrors(next);
     return Object.keys(next).length === 0;
   };
@@ -83,59 +112,129 @@ const RoomDataForm = forwardRef<
         capacity: capacity ? Number(capacity) : undefined,
         isActive,
         translations,
+        fileIds: galleryFileIds(galleryItems),
       };
     },
   }));
 
+  const handlePickerConfirm = (picked: FileItem[]) => {
+    const result = applyPickerSelection(galleryItems, picked);
+    if (result.overCap) {
+      setErrors((prev) => ({ ...prev, gallery: galleryErrorMessage("max") }));
+      return;
+    }
+    setGalleryItems(result.items);
+    setErrors((prev) => ({ ...prev, gallery: undefined }));
+  };
+
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
-        {mode === "create" && (
+    <>
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+          {mode === "create" && (
+            <div>
+              <Input
+                id="room-code"
+                label={t("room.form.code")}
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                error={errors.code}
+              />
+            </div>
+          )}
           <div>
             <Input
-              id="room-code"
-              label={t("room.form.code")}
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              error={errors.code}
+              id="room-number"
+              label={t("room.form.roomNumber")}
+              value={roomNumber}
+              onChange={(e) => setRoomNumber(e.target.value)}
             />
           </div>
-        )}
-        <div>
-          <Input
-            id="room-number"
-            label={t("room.form.roomNumber")}
-            value={roomNumber}
-            onChange={(e) => setRoomNumber(e.target.value)}
-          />
+          <div>
+            <Input
+              id="room-capacity"
+              label={t("room.form.capacity")}
+              type="number"
+              value={capacity}
+              onChange={(e) => setCapacity(e.target.value)}
+              hint={t("room.form.capacityHint")}
+            />
+          </div>
         </div>
-        <div>
-          <Input
-            id="room-capacity"
-            label={t("room.form.capacity")}
-            type="number"
-            value={capacity}
-            onChange={(e) => setCapacity(e.target.value)}
-            hint={t("room.form.capacityHint")}
-          />
-        </div>
+        <Checkbox id="room-active" label={t("shared.active")} checked={isActive} onChange={setIsActive} />
+        <FormField
+          id="room-gallery"
+          label={t("room.form.gallery")}
+          hint={errors.gallery ? undefined : t("room.form.galleryHint", { max: ROOM_GALLERY_MAX_FILES })}
+          error={errors.gallery}
+        >
+          <div className="space-y-3">
+            <Button btnType="button" variant="outline" size="sm" onClick={openPicker}>
+              <MdAdd className="mr-2" size={16} />
+              {t("room.form.galleryPick")}
+            </Button>
+            {galleryItems.length > 0 && (
+              <div className="space-y-2">
+                <div className="text-sm text-gray-600 dark:text-gray-400">
+                  {t("room.form.gallerySelected", { count: galleryItems.length, max: ROOM_GALLERY_MAX_FILES })}
+                </div>
+                <div className="grid max-h-[400px] grid-cols-2 gap-2 overflow-y-auto sm:grid-cols-4">
+                  {galleryItems.map((file, index) => (
+                    <div
+                      key={file.id}
+                      draggable
+                      onDragStart={() => setDragFromIndex(index)}
+                      onDragOver={(event) => event.preventDefault()}
+                      onDrop={() => {
+                        if (dragFromIndex === null) return;
+                        setGalleryItems((prev) => reorderGallery(prev, dragFromIndex, index));
+                        setDragFromIndex(null);
+                      }}
+                      onDragEnd={() => setDragFromIndex(null)}
+                      className={cn("cursor-grab", dragFromIndex === index && "opacity-60")}
+                    >
+                      <ImagePreviewCard
+                        imageUrl={file.url}
+                        alt={file.name}
+                        showDeleteButton
+                        enableImagePreview={false}
+                        onDelete={() => {
+                          setGalleryItems((prev) => prev.filter((item) => item.id !== file.id));
+                          setErrors((prev) => ({ ...prev, gallery: undefined }));
+                        }}
+                        fileInfo={{ name: file.name, size: file.size }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </FormField>
+        <TranslationTabsForm
+          locales={locales}
+          defaultLocaleId={defaultLocaleId}
+          value={translationMap}
+          onChange={setTranslationMap}
+          fields={["name", "description"]}
+          loading={loading}
+          error={error}
+          nameError={errors.name ? tCommon(errors.name) : undefined}
+          labels={{
+            name: t("room.form.name"),
+            description: t("room.form.description"),
+          }}
+        />
       </div>
-      <Checkbox id="room-active" label={t("shared.active")} checked={isActive} onChange={setIsActive} />
-      <TranslationTabsForm
-        locales={locales}
-        defaultLocaleId={defaultLocaleId}
-        value={translationMap}
-        onChange={setTranslationMap}
-        fields={["name", "description"]}
-        loading={loading}
-        error={error}
-        nameError={errors.name ? tCommon(errors.name) : undefined}
-        labels={{
-          name: t("room.form.name"),
-          description: t("room.form.description"),
-        }}
+      <FileSelectionModal
+        isOpen={isPickerOpen}
+        onClose={closePicker}
+        onConfirm={handlePickerConfirm}
+        initialSelectedItems={galleryItems}
+        maxSelected={ROOM_GALLERY_MAX_FILES}
+        onMaxReached={() => setErrors((prev) => ({ ...prev, gallery: galleryErrorMessage("max") }))}
       />
-    </div>
+    </>
   );
 });
 

--- a/src/pages/Facility/Room/RoomDataPage.tsx
+++ b/src/pages/Facility/Room/RoomDataPage.tsx
@@ -166,6 +166,7 @@ const RoomDataPage = () => {
                 isActive: d.isActive,
                 description: d.description,
                 translations: d.translations,
+                files: d.files,
               });
               openModal();
             }
@@ -236,7 +237,7 @@ const RoomDataPage = () => {
         title={formMode === "create" ? t("room.modal.createTitle") : t("room.modal.editTitle")}
         isOpen={isOpen}
         onClose={closeModal}
-        className="max-w-2xl w-full mx-4 p-6"
+        className="max-w-3xl w-full mx-4 p-6"
         footer={
           <>
             <Button variant="outline" size="sm" onClick={closeModal} disabled={submitting}>

--- a/src/pages/Facility/Room/roomGallery.test.ts
+++ b/src/pages/Facility/Room/roomGallery.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { FileItem } from "@/pages/Content/File/types";
+import {
+  ROOM_GALLERY_MAX_FILES,
+  applyPickerSelection,
+  canAddGalleryPick,
+  galleryFileIds,
+  hydrateGalleryFromFiles,
+  reorderGallery,
+  uniqueGalleryItems,
+  validateGallery,
+} from "./roomGallery";
+
+const item = (id: string): FileItem => ({ id, url: `https://cdn.example/${id}.jpg`, name: `${id}.jpg` });
+
+describe("room gallery helpers", () => {
+  it("maps preview order to file ids", () => {
+    expect(galleryFileIds([item("b"), item("a")])).toEqual(["b", "a"]);
+  });
+
+  it("ignores duplicate picks while keeping first-seen order", () => {
+    expect(uniqueGalleryItems([item("a"), item("b"), item("a")]).map((file) => file.id)).toEqual(["a", "b"]);
+  });
+
+  it("reorders by drag indexes", () => {
+    const reordered = reorderGallery([item("a"), item("b"), item("c")], 2, 0);
+    expect(reordered.map((file) => file.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("does not allow adding a new pick at the cap", () => {
+    expect(canAddGalleryPick(ROOM_GALLERY_MAX_FILES, false)).toBe(false);
+    expect(canAddGalleryPick(ROOM_GALLERY_MAX_FILES, true)).toBe(true);
+    expect(canAddGalleryPick(ROOM_GALLERY_MAX_FILES - 1, false)).toBe(true);
+  });
+
+  it("keeps current gallery order and appends new unique picks", () => {
+    const result = applyPickerSelection([item("b"), item("a")], [item("a"), item("c"), item("b"), item("a")]);
+    expect(result.overCap).toBe(false);
+    expect(result.items.map((file) => file.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("flags over-cap without dropping extras from the result set", () => {
+    const current = Array.from({ length: 10 }, (_, index) => item(`keep-${index}`));
+    const picked = [...current, item("extra")];
+    const result = applyPickerSelection(current, picked);
+    expect(result.overCap).toBe(true);
+    expect(result.items).toHaveLength(11);
+  });
+
+  it("validates uniqueness and cap", () => {
+    expect(validateGallery([item("a"), item("a")])).toBe("duplicate");
+    const over = Array.from({ length: 11 }, (_, index) => item(`f-${index}`));
+    expect(validateGallery(over)).toBe("max");
+    expect(validateGallery([item("a")])).toBeNull();
+  });
+
+  it("hydrates from room detail files in API order", () => {
+    const items = hydrateGalleryFromFiles([
+      {
+        id: "second",
+        originalName: "second.jpg",
+        url: "https://cdn.example/second.jpg",
+      },
+      {
+        id: "first",
+        originalName: "first.jpg",
+        url: "https://cdn.example/first.jpg",
+      },
+    ]);
+    expect(items.map((file) => file.id)).toEqual(["second", "first"]);
+    expect(items[0].url).toBe("https://cdn.example/second.jpg");
+  });
+});

--- a/src/pages/Facility/Room/roomGallery.test.ts
+++ b/src/pages/Facility/Room/roomGallery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { FileItem } from "@/pages/Content/File/types";
 import {
   ROOM_GALLERY_MAX_FILES,
+  appendUploadedGalleryFiles,
   applyPickerSelection,
   canAddGalleryPick,
   galleryFileIds,
@@ -37,6 +38,26 @@ describe("room gallery helpers", () => {
     const result = applyPickerSelection([item("b"), item("a")], [item("a"), item("c"), item("b"), item("a")]);
     expect(result.overCap).toBe(false);
     expect(result.items.map((file) => file.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("appends uploaded images that are not already in the gallery", () => {
+    const result = appendUploadedGalleryFiles([item("a")], [item("a"), item("b"), item("b")]);
+    expect(result.overCap).toBe(false);
+    expect(result.items.map((file) => file.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not append uploaded images past the gallery cap", () => {
+    const current = Array.from({ length: ROOM_GALLERY_MAX_FILES }, (_, index) => item(`keep-${index}`));
+    const result = appendUploadedGalleryFiles(current, [item("extra")]);
+    expect(result.overCap).toBe(true);
+    expect(result.items).toHaveLength(ROOM_GALLERY_MAX_FILES);
+  });
+
+  it("fills remaining gallery slots then flags over-cap for the rest", () => {
+    const current = Array.from({ length: ROOM_GALLERY_MAX_FILES - 1 }, (_, index) => item(`keep-${index}`));
+    const result = appendUploadedGalleryFiles(current, [item("fits"), item("overflow")]);
+    expect(result.overCap).toBe(true);
+    expect(result.items.map((file) => file.id)).toEqual([...current.map((file) => file.id), "fits"]);
   });
 
   it("flags over-cap without dropping extras from the result set", () => {

--- a/src/pages/Facility/Room/roomGallery.ts
+++ b/src/pages/Facility/Room/roomGallery.ts
@@ -1,0 +1,86 @@
+import type { FileItem } from "@/pages/Content/File/types";
+
+export interface RoomGalleryFile {
+  id: string;
+  originalName: string;
+  url?: string;
+  sizeBytes?: number;
+}
+
+export const ROOM_GALLERY_MAX_FILES = 10;
+
+export type RoomGalleryError = "max" | "duplicate";
+
+export const galleryFileIds = (items: FileItem[]): string[] => items.map((item) => item.id);
+
+export const uniqueGalleryItems = (items: FileItem[]): FileItem[] => {
+  const seen = new Set<string>();
+  const unique: FileItem[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) {
+      continue;
+    }
+    seen.add(item.id);
+    unique.push(item);
+  }
+  return unique;
+};
+
+export const reorderGallery = <T>(items: T[], fromIndex: number, toIndex: number): T[] => {
+  if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0 || fromIndex >= items.length || toIndex >= items.length) {
+    return items;
+  }
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+};
+
+export const canAddGalleryPick = (
+  selectedCount: number,
+  isAlreadySelected: boolean,
+  max: number = ROOM_GALLERY_MAX_FILES
+): boolean => {
+  if (isAlreadySelected) {
+    return true;
+  }
+  return selectedCount < max;
+};
+
+export const applyPickerSelection = (
+  current: FileItem[],
+  picked: FileItem[],
+  max: number = ROOM_GALLERY_MAX_FILES
+): { items: FileItem[]; overCap: boolean } => {
+  const uniquePicked = uniqueGalleryItems(picked);
+  const pickedIds = new Set(uniquePicked.map((item) => item.id));
+  const kept = current.filter((item) => pickedIds.has(item.id));
+  const keptIds = new Set(kept.map((item) => item.id));
+  const appended = uniquePicked.filter((item) => !keptIds.has(item.id));
+  const items = [...kept, ...appended];
+  return { items, overCap: items.length > max };
+};
+
+export const validateGallery = (items: FileItem[], max: number = ROOM_GALLERY_MAX_FILES): RoomGalleryError | null => {
+  if (items.length > max) {
+    return "max";
+  }
+  if (uniqueGalleryItems(items).length !== items.length) {
+    return "duplicate";
+  }
+  return null;
+};
+
+export const hydrateGalleryFromFiles = (files?: RoomGalleryFile[]): FileItem[] => {
+  if (!files || files.length === 0) {
+    return [];
+  }
+  return uniqueGalleryItems(
+    files.map((file) => ({
+      id: file.id,
+      url: file.url || "",
+      name: file.originalName,
+      size: file.sizeBytes,
+    }))
+  );
+};

--- a/src/pages/Facility/Room/roomGallery.ts
+++ b/src/pages/Facility/Room/roomGallery.ts
@@ -1,4 +1,5 @@
 import type { FileItem } from "@/pages/Content/File/types";
+import { appendUploadedFiles } from "@/pages/Content/File/utils";
 
 export interface RoomGalleryFile {
   id: string;
@@ -59,6 +60,14 @@ export const applyPickerSelection = (
   const appended = uniquePicked.filter((item) => !keptIds.has(item.id));
   const items = [...kept, ...appended];
   return { items, overCap: items.length > max };
+};
+
+export const appendUploadedGalleryFiles = (
+  current: FileItem[],
+  uploaded: FileItem[],
+  max: number = ROOM_GALLERY_MAX_FILES
+): { items: FileItem[]; overCap: boolean } => {
+  return appendUploadedFiles(current, uploaded, max);
 };
 
 export const validateGallery = (items: FileItem[], max: number = ROOM_GALLERY_MAX_FILES): RoomGalleryError | null => {


### PR DESCRIPTION
## Summary

Room create/edit now lets operators pick up to ten unique images from the content library, preview and drag-reorder them, and save ordered `fileIds` as a full gallery replace (empty list clears). Edit hydrates from Room detail `files`. The Room list is unchanged (no thumbnails). Picker upload is out of scope.

Closes #38

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Images-only `FileSelectionModal` (no upload in this PR).
- Cap 10: picker cannot add more; over-cap is a Form field error, not a toast.
- Duplicate picks are ignored (first-seen order). Save always sends `fileIds`.
- Depends on core-api Room gallery bind (`fileIds` / detail `files`).

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm run test`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge