### PR TITLE
feat: show File association preview on delete (#39)

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -115,6 +115,7 @@ export const API_ENDPOINTS = {
       SUMMARY: `${ADMIN_API_PREFIX}/content/file/summary`,
       UPLOAD: `${ADMIN_API_PREFIX}/content/file/upload`,
       BULK_DELETE: `${ADMIN_API_PREFIX}/content/file/bulk`,
+      ASSOCIATION_PREVIEW: `${ADMIN_API_PREFIX}/content/file/association-preview`,
     },
   },
 

--- a/src/api/services/fileService.ts
+++ b/src/api/services/fileService.ts
@@ -2,6 +2,7 @@ import { API_ENDPOINTS, httpClient } from "@/api";
 import type {
   BulkDeleteRequest,
   BulkDeleteResponse,
+  FileAssociationPreviewResponse,
   FilePagesParams,
   FilePagesResponse,
   FileSummaryResponse,
@@ -40,6 +41,10 @@ export const fileService = {
         }
       },
     });
+  },
+
+  async previewAssociations(payload: BulkDeleteRequest) {
+    return httpClient.post<FileAssociationPreviewResponse>(API_ENDPOINTS.CONTENT.FILES.ASSOCIATION_PREVIEW, payload);
   },
 
   async bulkDelete(payload: BulkDeleteRequest) {

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -80,9 +80,14 @@
     "delete": {
       "title": "Confirm Delete",
       "confirmMessage": "Delete {{count}} selected file(s)? This action cannot be undone.",
+      "associationWarning": "These files will be removed from every bound resource, including deleted rooms.",
+      "loadingAssociations": "Loading bound resources…",
+      "noAssociations": "No bound resources.",
+      "deletedResource": "(deleted)",
       "submit": "Delete",
       "submitting": "Deleting...",
-      "failed": "Failed to delete files"
+      "failed": "Failed to delete files",
+      "previewFailed": "Failed to load file associations"
     },
     "preview": {
       "title": "Image Preview"

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -80,9 +80,14 @@
     "delete": {
       "title": "确认删除",
       "confirmMessage": "确定要删除所选的 {{count}} 个文件吗？此操作无法撤销。",
+      "associationWarning": "这些文件会从所有已绑定资源移除，包含已删除的房间。",
+      "loadingAssociations": "正在加载绑定资源…",
+      "noAssociations": "没有绑定资源。",
+      "deletedResource": "（已删除）",
       "submit": "删除",
       "submitting": "删除中...",
-      "failed": "删除文件失败"
+      "failed": "删除文件失败",
+      "previewFailed": "无法加载文件关联"
     },
     "preview": {
       "title": "图片预览"

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -80,9 +80,14 @@
     "delete": {
       "title": "確認刪除",
       "confirmMessage": "確定要刪除所選的 {{count}} 個檔案嗎？此操作無法復原。",
+      "associationWarning": "這些檔案會從所有已綁定資源移除，包含已刪除的房間。",
+      "loadingAssociations": "正在載入綁定資源…",
+      "noAssociations": "沒有綁定資源。",
+      "deletedResource": "（已刪除）",
       "submit": "刪除",
       "submitting": "刪除中...",
-      "failed": "刪除檔案失敗"
+      "failed": "刪除檔案失敗",
+      "previewFailed": "無法載入檔案關聯"
     },
     "preview": {
       "title": "圖片預覽"

--- a/src/pages/Content/File/FileDataPage.tsx
+++ b/src/pages/Content/File/FileDataPage.tsx
@@ -16,7 +16,8 @@ import FileTableList from "./FileTableList";
 import FileUploadForm, { type FileUploadFormHandle } from "./FileUploadForm";
 import MediaCategoryCards from "./MediaCategoryCards";
 import StorageDetailsCard from "./StorageDetailsCard";
-import type { FileItem, FileSummaryResponse, MediaCategory, SortOrder } from "./types";
+import { groupFileAssociationPreview } from "./fileAssociationPreview";
+import type { FileDeleteAssociationGroup, FileItem, FileSummaryResponse, MediaCategory, SortOrder } from "./types";
 import {
   convertFileGridItemToFileItem,
   convertSortOrderToApiParams,
@@ -40,6 +41,9 @@ const FileDataPage = () => {
   const [totalEntries, setTotalEntries] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [deleteIds, setDeleteIds] = useState<string[]>([]);
+  const [deleteGroups, setDeleteGroups] = useState<FileDeleteAssociationGroup[]>([]);
   const [allowMixedUpload, setAllowMixedUpload] = useState(false);
 
   const { isOpen: isUploadModalOpen, openModal: openUploadModal, closeModal: closeUploadModal } = useModal();
@@ -155,22 +159,57 @@ const FileDataPage = () => {
     });
   }, [files, isAllSelected]);
 
+  const fileNames = useMemo(() => {
+    const names: Record<string, string> = {};
+    files.forEach((file) => {
+      names[file.id] = file.name;
+    });
+    return names;
+  }, [files]);
+
+  const loadDeletePreview = useCallback(
+    async (ids: string[]) => {
+      if (ids.length === 0) {
+        return;
+      }
+      setDeleteIds(ids);
+      setDeleteGroups(groupFileAssociationPreview(ids, []));
+      setLoadingPreview(true);
+      openDeleteModal();
+      try {
+        const response = await fileService.previewAssociations({ ids });
+        if (!response.success) {
+          throw new Error(response.message || t("file.delete.previewFailed"));
+        }
+        setDeleteGroups(groupFileAssociationPreview(ids, response.data.items || []));
+      } catch (error) {
+        notifyApiError(error, {
+          title: t("file.delete.previewFailed"),
+          fallbackDescription: t("file.delete.previewFailed"),
+        });
+        closeDeleteModal();
+      } finally {
+        setLoadingPreview(false);
+      }
+    },
+    [closeDeleteModal, openDeleteModal, t]
+  );
+
   const handleBatchDelete = useCallback(() => {
-    if (selectedKeys.length === 0) {
-      return;
-    }
-    openDeleteModal();
-  }, [openDeleteModal, selectedKeys.length]);
+    void loadDeletePreview(selectedKeys);
+  }, [loadDeletePreview, selectedKeys]);
 
   const handleDeleteConfirm = useCallback(async () => {
-    if (selectedKeys.length === 0) {
+    if (deleteIds.length === 0 || loadingPreview) {
       return;
     }
     try {
       setDeleting(true);
-      const response = await fileService.bulkDelete({ ids: selectedKeys });
+      const response = await fileService.bulkDelete({ ids: deleteIds });
       if (response.success) {
         setSelectedKeys([]);
+        setDeleteIds([]);
+        setDeleteGroups([]);
         notifySuccess({ title: t("common:feedback.deleted") });
         closeDeleteModal();
         await refreshAll();
@@ -183,14 +222,14 @@ const FileDataPage = () => {
     } finally {
       setDeleting(false);
     }
-  }, [closeDeleteModal, refreshAll, selectedKeys, t]);
+  }, [closeDeleteModal, deleteIds, loadingPreview, refreshAll, t]);
 
   const handleDeleteOne = useCallback(
     (fileId: string) => {
       setSelectedKeys([fileId]);
-      openDeleteModal();
+      void loadDeletePreview([fileId]);
     },
-    [openDeleteModal]
+    [loadDeletePreview]
   );
 
   const handleCloseUploadModal = useCallback(async () => {
@@ -428,7 +467,10 @@ const FileDataPage = () => {
         className="mx-4 w-full max-w-[560px] p-6"
       >
         <FileDeleteForm
-          fileCount={selectedKeys.length}
+          fileCount={deleteIds.length}
+          fileNames={fileNames}
+          groups={deleteGroups}
+          loadingPreview={loadingPreview}
           onSubmit={handleDeleteConfirm}
           onCancel={closeDeleteModal}
           submitting={deleting}

--- a/src/pages/Content/File/FileDeleteForm.tsx
+++ b/src/pages/Content/File/FileDeleteForm.tsx
@@ -1,26 +1,63 @@
 import { Button } from "@efcnewlife/newlife-ui";
 import { useTranslation } from "react-i18next";
+import type { FileDeleteAssociationGroup } from "./types";
 
 interface FileDeleteFormProps {
   fileCount: number;
+  fileNames: Record<string, string>;
+  groups: FileDeleteAssociationGroup[];
+  loadingPreview?: boolean;
   onSubmit: () => void;
   onCancel: () => void;
   submitting?: boolean;
 }
 
-const FileDeleteForm = ({ fileCount, onSubmit, onCancel, submitting = false }: FileDeleteFormProps) => {
+const FileDeleteForm = ({
+  fileCount,
+  fileNames,
+  groups,
+  loadingPreview = false,
+  onSubmit,
+  onCancel,
+  submitting = false,
+}: FileDeleteFormProps) => {
   const { t } = useTranslation("content");
+  const confirmDisabled = submitting || loadingPreview;
 
   return (
     <div className="space-y-6">
       <p className="text-sm text-gray-600 dark:text-gray-300">
         {t("file.delete.confirmMessage", { count: fileCount })}
       </p>
+      <p className="text-sm text-gray-600 dark:text-gray-300">{t("file.delete.associationWarning")}</p>
+      {loadingPreview ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">{t("file.delete.loadingAssociations")}</p>
+      ) : (
+        <ul className="max-h-64 space-y-3 overflow-y-auto text-sm">
+          {groups.map((group) => (
+            <li key={group.fileId}>
+              <p className="font-medium text-gray-900 dark:text-white/90">{fileNames[group.fileId] ?? group.fileId}</p>
+              {group.bindings.length === 0 ? (
+                <p className="mt-1 text-gray-500 dark:text-gray-400">{t("file.delete.noAssociations")}</p>
+              ) : (
+                <ul className="mt-1 list-disc space-y-1 pl-5 text-gray-600 dark:text-gray-300">
+                  {group.bindings.map((binding) => (
+                    <li key={`${binding.resourceKind}-${binding.resourceId}`}>
+                      {binding.displayName}
+                      {binding.isDeleted ? ` ${t("file.delete.deletedResource")}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
       <div className="flex justify-end gap-3">
         <Button variant="outline" size="sm" onClick={onCancel} disabled={submitting}>
           {t("common:cancel")}
         </Button>
-        <Button variant="primary" size="sm" onClick={onSubmit} disabled={submitting}>
+        <Button variant="primary" size="sm" onClick={onSubmit} disabled={confirmDisabled}>
           {submitting ? t("file.delete.submitting") : t("file.delete.submit")}
         </Button>
       </div>

--- a/src/pages/Content/File/fileAssociationPreview.test.ts
+++ b/src/pages/Content/File/fileAssociationPreview.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { FileAssociationPreviewItem } from "./types";
+import { groupFileAssociationPreview } from "./fileAssociationPreview";
+
+const binding = (
+  overrides: Partial<FileAssociationPreviewItem> & Pick<FileAssociationPreviewItem, "fileId">
+): FileAssociationPreviewItem => ({
+  resourceKind: "facility.room",
+  resourceId: "room-1",
+  displayName: "Sanctuary",
+  isDeleted: false,
+  ...overrides,
+});
+
+describe("groupFileAssociationPreview", () => {
+  it("keeps every selected file in order, including files with no bindings", () => {
+    const items = [binding({ fileId: "file-b", displayName: "Hall A" })];
+    const groups = groupFileAssociationPreview(["file-a", "file-b"], items);
+
+    expect(groups.map((group) => group.fileId)).toEqual(["file-a", "file-b"]);
+    expect(groups[0].bindings).toEqual([]);
+    expect(groups[1].bindings.map((row) => row.displayName)).toEqual(["Hall A"]);
+  });
+
+  it("lists named bindings and marks soft-deleted rooms", () => {
+    const items = [
+      binding({ fileId: "file-1", resourceId: "room-live", displayName: "Sanctuary", isDeleted: false }),
+      binding({ fileId: "file-1", resourceId: "room-gone", displayName: "OLD-HALL", isDeleted: true }),
+    ];
+    const groups = groupFileAssociationPreview(["file-1"], items);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].bindings).toEqual([
+      {
+        fileId: "file-1",
+        resourceKind: "facility.room",
+        resourceId: "room-live",
+        displayName: "Sanctuary",
+        isDeleted: false,
+      },
+      {
+        fileId: "file-1",
+        resourceKind: "facility.room",
+        resourceId: "room-gone",
+        displayName: "OLD-HALL",
+        isDeleted: true,
+      },
+    ]);
+  });
+
+  it("ignores bindings for files that are not selected", () => {
+    const items = [binding({ fileId: "other", displayName: "Ignored" })];
+    const groups = groupFileAssociationPreview(["file-1"], items);
+
+    expect(groups).toEqual([{ fileId: "file-1", bindings: [] }]);
+  });
+});

--- a/src/pages/Content/File/fileAssociationPreview.ts
+++ b/src/pages/Content/File/fileAssociationPreview.ts
@@ -1,0 +1,24 @@
+import type { FileAssociationPreviewItem, FileDeleteAssociationGroup } from "./types";
+
+export const groupFileAssociationPreview = (
+  selectedIds: string[],
+  items: FileAssociationPreviewItem[]
+): FileDeleteAssociationGroup[] => {
+  const bindingsByFileId = new Map<string, FileAssociationPreviewItem[]>();
+  selectedIds.forEach((fileId) => {
+    bindingsByFileId.set(fileId, []);
+  });
+
+  items.forEach((item) => {
+    const bindings = bindingsByFileId.get(item.fileId);
+    if (!bindings) {
+      return;
+    }
+    bindings.push(item);
+  });
+
+  return selectedIds.map((fileId) => ({
+    fileId,
+    bindings: bindingsByFileId.get(fileId) ?? [],
+  }));
+};

--- a/src/pages/Content/File/types.ts
+++ b/src/pages/Content/File/types.ts
@@ -58,6 +58,23 @@ export interface BulkDeleteResponse {
   failedItems?: FileBase[] | null;
 }
 
+export interface FileAssociationPreviewItem {
+  fileId: string;
+  resourceKind: string;
+  resourceId: string;
+  displayName: string;
+  isDeleted: boolean;
+}
+
+export interface FileAssociationPreviewResponse {
+  items: FileAssociationPreviewItem[];
+}
+
+export interface FileDeleteAssociationGroup {
+  fileId: string;
+  bindings: FileAssociationPreviewItem[];
+}
+
 export type SortOrder = "name_asc" | "name_desc" | "date_asc" | "date_desc" | "size_asc" | "size_desc";
 
 export interface FilePagesParams extends Record<string, unknown> {


### PR DESCRIPTION
## Summary

Content Files bulk/single delete loads Core association preview and shows one confirmation listing each selected file's bound resources by name or code, including soft-deleted Rooms labelled as deleted. Confirm then calls existing bulk delete with Operation feedback.

Stacked on `feat/38-room-gallery-form` (Room gallery 4/4). Depends on Core `POST /admin/api/v1/content/file/association-preview` (core-api #82).

Closes #39

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Preview failure closes the dialog so Operators cannot delete without seeing the named list.
- Files with no bindings still appear in the same dialog with an empty binding list.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] `pnpm run format:check` (CI)

## Checklist

- [x] PR targets **`feat/38-room-gallery-form`** (stacked; not `main`)
- [ ] CI green before merge