### PR TITLE
feat: add Content File upload to the Room gallery picker

### DIFF
--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -89,7 +89,9 @@
     },
     "picker": {
       "title": "Choose images",
-      "confirm": "Confirm ({{count}})"
+      "confirm": "Confirm ({{count}})",
+      "upload": "Upload",
+      "uploadTitle": "Upload images"
     }
   }
 }

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -89,7 +89,9 @@
     },
     "picker": {
       "title": "选择图片",
-      "confirm": "确认选择（{{count}}）"
+      "confirm": "确认选择（{{count}}）",
+      "upload": "上传",
+      "uploadTitle": "上传图片"
     }
   }
 }

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -89,7 +89,9 @@
     },
     "picker": {
       "title": "選擇圖片",
-      "confirm": "確認選擇（{{count}}）"
+      "confirm": "確認選擇（{{count}}）",
+      "upload": "上傳",
+      "uploadTitle": "上傳圖片"
     }
   }
 }

--- a/src/pages/Content/File/FileSelectionModal.tsx
+++ b/src/pages/Content/File/FileSelectionModal.tsx
@@ -9,9 +9,11 @@ import { notifyApiError } from "@/utils/operationFeedback";
 import { Button, Modal, Select } from "@efcnewlife/newlife-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MdUpload } from "react-icons/md";
 import FileGrid from "./FileGrid";
+import FileUploadForm, { type FileUploadFormHandle } from "./FileUploadForm";
 import type { FileItem, SortOrder } from "./types";
-import { convertFileGridItemToFileItem, convertSortOrderToApiParams } from "./utils";
+import { appendUploadedFiles, convertFileGridItemToFileItem, convertSortOrderToApiParams } from "./utils";
 
 const PAGE_SIZE_OPTIONS = [25, 50, 75, 100];
 
@@ -40,12 +42,16 @@ const FileSelectionModal = ({
   const [loading, setLoading] = useState(false);
   const [files, setFiles] = useState<FileItem[]>([]);
   const [totalEntries, setTotalEntries] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [isUploadOpen, setIsUploadOpen] = useState(false);
   const fileCacheRef = useRef<Map<string, FileItem>>(new Map());
+  const fileUploadFormRef = useRef<FileUploadFormHandle>(null);
 
   const sortParams = useMemo(() => convertSortOrderToApiParams(sortOrder), [sortOrder]);
 
   useEffect(() => {
     if (!isOpen) {
+      setIsUploadOpen(false);
       return;
     }
     const initialIds = initialSelectedItems.map((item) => item.id);
@@ -114,6 +120,76 @@ const FileSelectionModal = ({
     [maxSelected, onMaxReached]
   );
 
+  const selectedItemsFromKeys = useCallback((keys: string[]): FileItem[] => {
+    return keys.map((id) => fileCacheRef.current.get(id)).filter((item): item is FileItem => Boolean(item));
+  }, []);
+
+  const handleCloseUpload = useCallback(() => {
+    setIsUploadOpen(false);
+    fileUploadFormRef.current?.clearFiles();
+  }, []);
+
+  const handleFileUpload = useCallback(async () => {
+    if (!fileUploadFormRef.current?.validate()) {
+      return;
+    }
+    const uploadFiles = fileUploadFormRef.current.getFiles();
+    if (uploadFiles.length === 0) {
+      return;
+    }
+    try {
+      setUploading(true);
+      const uploadedItems: FileItem[] = [];
+      for (let index = 0; index < uploadFiles.length; index += 1) {
+        const file = uploadFiles[index];
+        fileUploadFormRef.current?.setUploadStatus(index, "uploading");
+        try {
+          const response = await fileService.uploadOne(file, "images", (progress) => {
+            fileUploadFormRef.current?.setUploadProgress(index, progress);
+          });
+          if (response.success && response.data?.id) {
+            const duplicate = response.data.duplicate === true;
+            const message = duplicate ? t("file.upload.duplicateExisting") : t("file.upload.success");
+            fileUploadFormRef.current?.setUploadStatus(index, "success", undefined, message);
+            uploadedItems.push({
+              id: response.data.id,
+              url: "",
+              name: file.name,
+              size: file.size,
+              contentType: file.type,
+            });
+          } else {
+            fileUploadFormRef.current?.setUploadStatus(index, "error", response.message || t("file.upload.error"));
+          }
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : t("file.upload.error");
+          fileUploadFormRef.current?.setUploadStatus(index, "error", message);
+        }
+      }
+      uploadedItems.forEach((item) => {
+        const cached = fileCacheRef.current.get(item.id);
+        if (!cached) {
+          fileCacheRef.current.set(item.id, item);
+        }
+      });
+      await fetchPages();
+      setSelectedKeys((prev) => {
+        const mergedUploads = uploadedItems.map((item) => fileCacheRef.current.get(item.id) ?? item);
+        const result = appendUploadedFiles(selectedItemsFromKeys(prev), mergedUploads, maxSelected);
+        if (result.overCap) {
+          onMaxReached?.();
+        }
+        result.items.forEach((item) => {
+          fileCacheRef.current.set(item.id, item);
+        });
+        return result.items.map((item) => item.id);
+      });
+      handleCloseUpload();
+    } finally {
+      setUploading(false);
+    }
+  }, [fetchPages, handleCloseUpload, maxSelected, onMaxReached, selectedItemsFromKeys, t]);
+
   const sortOptions = useMemo(
     () => [
       { value: "date_desc", label: t("file.sort.dateDesc") },
@@ -128,6 +204,16 @@ const FileSelectionModal = ({
 
   const toolbarButtons: PageButtonType[] = useMemo(
     () => [
+      {
+        key: "upload",
+        text: t("file.picker.upload"),
+        icon: <MdUpload className="size-4" />,
+        align: "left",
+        variant: "primary",
+        size: "md",
+        onClick: () => setIsUploadOpen(true),
+        permission: Verb.Create,
+      },
       CommonPageButton.REFRESH(() => {
         void fetchPages();
       }),
@@ -164,26 +250,30 @@ const FileSelectionModal = ({
   );
 
   const handleConfirm = useCallback(() => {
-    const selectedFiles = selectedKeys
-      .map((id) => fileCacheRef.current.get(id))
-      .filter((item): item is FileItem => Boolean(item));
+    const selectedFiles = selectedItemsFromKeys(selectedKeys);
     onConfirm(selectedFiles);
     onClose();
-  }, [onClose, onConfirm, selectedKeys]);
+  }, [onClose, onConfirm, selectedItemsFromKeys, selectedKeys]);
 
   return (
     <Modal
-      title={t("file.picker.title")}
+      title={isUploadOpen ? t("file.picker.uploadTitle") : t("file.picker.title")}
       isOpen={isOpen}
       onClose={onClose}
       className="mx-4 flex max-h-[90vh] w-full max-w-[90vw] flex-col bg-white p-6 dark:bg-gray-900"
     >
       <div className="flex min-h-0 max-h-[calc(90vh-120px)] flex-1 flex-col">
-        <div className="shrink-0">
-          <DataTableToolbar buttons={toolbarButtons} resource={Resource.ContentFile} />
-        </div>
+        {!isUploadOpen && (
+          <div className="shrink-0">
+            <DataTableToolbar buttons={toolbarButtons} resource={Resource.ContentFile} />
+          </div>
+        )}
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          {loading ? (
+          {isUploadOpen ? (
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <FileUploadForm ref={fileUploadFormRef} mediaCategory="images" />
+            </div>
+          ) : loading ? (
             <div className="flex h-[400px] items-center justify-center">
               <LoadingSpinner />
             </div>
@@ -197,25 +287,38 @@ const FileSelectionModal = ({
                   currentPage={currentPage}
                   totalPages={totalPages}
                   rowsPerPage={itemsPerPage}
-                  totalEntries={totalEntries}
-                  pageSizeOptions={PAGE_SIZE_OPTIONS}
                   onPageChange={setCurrentPage}
                   onRowsPerPageChange={(size) => {
                     setItemsPerPage(size);
                     setCurrentPage(1);
                   }}
+                  totalEntries={totalEntries}
+                  pageSizeOptions={PAGE_SIZE_OPTIONS}
                 />
               </div>
             </>
           )}
         </div>
         <div className="mt-4 flex shrink-0 justify-end gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
-          <Button variant="outline" onClick={onClose}>
-            {t("common:cancel")}
-          </Button>
-          <Button variant="primary" onClick={handleConfirm}>
-            {t("file.picker.confirm", { count: selectedKeys.length })}
-          </Button>
+          {isUploadOpen ? (
+            <>
+              <Button variant="outline" onClick={handleCloseUpload} disabled={uploading}>
+                {t("file.upload.close")}
+              </Button>
+              <Button variant="primary" onClick={() => void handleFileUpload()} disabled={uploading}>
+                {uploading ? t("file.upload.submitting") : t("file.upload.submit")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={onClose}>
+                {t("common:cancel")}
+              </Button>
+              <Button variant="primary" onClick={handleConfirm}>
+                {t("file.picker.confirm", { count: selectedKeys.length })}
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/pages/Content/File/utils.ts
+++ b/src/pages/Content/File/utils.ts
@@ -92,6 +92,30 @@ export const convertFileGridItemToFileItem = (item: FileGridItem): FileItem => {
   };
 };
 
+export const appendUploadedFiles = (
+  current: FileItem[],
+  uploaded: FileItem[],
+  max: number
+): { items: FileItem[]; overCap: boolean } => {
+  const currentIds = new Set(current.map((item) => item.id));
+  const seenUpload = new Set<string>();
+  const appended: FileItem[] = [];
+  let overCap = false;
+  for (const item of uploaded) {
+    if (seenUpload.has(item.id) || currentIds.has(item.id)) {
+      continue;
+    }
+    seenUpload.add(item.id);
+    if (current.length + appended.length >= max) {
+      overCap = true;
+      continue;
+    }
+    appended.push(item);
+    currentIds.add(item.id);
+  }
+  return { items: [...current, ...appended], overCap };
+};
+
 export const getCategorySharePercent = (sizeBytes: number, totalBytes: number): number => {
   if (totalBytes <= 0) return 0;
   return Math.round((sizeBytes / totalBytes) * 100);

--- a/src/pages/Facility/Room/roomGallery.test.ts
+++ b/src/pages/Facility/Room/roomGallery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { FileItem } from "@/pages/Content/File/types";
 import {
   ROOM_GALLERY_MAX_FILES,
+  appendUploadedGalleryFiles,
   applyPickerSelection,
   canAddGalleryPick,
   galleryFileIds,
@@ -37,6 +38,26 @@ describe("room gallery helpers", () => {
     const result = applyPickerSelection([item("b"), item("a")], [item("a"), item("c"), item("b"), item("a")]);
     expect(result.overCap).toBe(false);
     expect(result.items.map((file) => file.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("appends uploaded images that are not already in the gallery", () => {
+    const result = appendUploadedGalleryFiles([item("a")], [item("a"), item("b"), item("b")]);
+    expect(result.overCap).toBe(false);
+    expect(result.items.map((file) => file.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not append uploaded images past the gallery cap", () => {
+    const current = Array.from({ length: ROOM_GALLERY_MAX_FILES }, (_, index) => item(`keep-${index}`));
+    const result = appendUploadedGalleryFiles(current, [item("extra")]);
+    expect(result.overCap).toBe(true);
+    expect(result.items).toHaveLength(ROOM_GALLERY_MAX_FILES);
+  });
+
+  it("fills remaining gallery slots then flags over-cap for the rest", () => {
+    const current = Array.from({ length: ROOM_GALLERY_MAX_FILES - 1 }, (_, index) => item(`keep-${index}`));
+    const result = appendUploadedGalleryFiles(current, [item("fits"), item("overflow")]);
+    expect(result.overCap).toBe(true);
+    expect(result.items.map((file) => file.id)).toEqual([...current.map((file) => file.id), "fits"]);
   });
 
   it("flags over-cap without dropping extras from the result set", () => {

--- a/src/pages/Facility/Room/roomGallery.ts
+++ b/src/pages/Facility/Room/roomGallery.ts
@@ -1,4 +1,5 @@
 import type { FileItem } from "@/pages/Content/File/types";
+import { appendUploadedFiles } from "@/pages/Content/File/utils";
 
 export interface RoomGalleryFile {
   id: string;
@@ -59,6 +60,14 @@ export const applyPickerSelection = (
   const appended = uniquePicked.filter((item) => !keptIds.has(item.id));
   const items = [...kept, ...appended];
   return { items, overCap: items.length > max };
+};
+
+export const appendUploadedGalleryFiles = (
+  current: FileItem[],
+  uploaded: FileItem[],
+  max: number = ROOM_GALLERY_MAX_FILES
+): { items: FileItem[]; overCap: boolean } => {
+  return appendUploadedFiles(current, uploaded, max);
 };
 
 export const validateGallery = (items: FileItem[], max: number = ROOM_GALLERY_MAX_FILES): RoomGalleryError | null => {


### PR DESCRIPTION
## Summary

Adds image upload inside the Room gallery picker, gated by Content File create permission. Uploads go through the existing Content File API (`images`) and are appended to the current selection with the gallery cap and uniqueness rules.

Stacked on `feat/38-room-gallery-form` (Room gallery picker). Closes #40.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Upload lives in the same picker modal (panel switch), not a Room-only store.
- Toolbar Upload uses `content:file:create` via `DataTableToolbar`; library pick still works without that permission.
- `appendUploadedFiles` is the seam for cap / duplicate handling.

## Testing

- [x] `pnpm test`
- [x] `pnpm run type-check`

## Checklist

- [x] PR targets **`feat/38-room-gallery-form`** (stacked; not `main`)
- [ ] CI green before merge


Made with [Cursor](https://cursor.com)