### PR TITLE
feat: Content Legal Documents list and edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ Unknown keys render `Blank`. Keep backend resource `key` strings identical to th
 | `ORG_POSITION`                  | `PositionManagement`         |
 | `MEMBER_PERSON`                 | `PersonManagement`           |
 | `CONTENT_FILE`                  | `FileManagement`             |
+| `CONTENT_LEGAL_DOCUMENT`        | `LegalDocumentManagement`    |
 
 ---
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,3 +121,25 @@ _Avoid_: row highlight as selection, hover action / hover callback as the defaul
 **Selected row**:
 A DataTable data row that is currently in the selection set (checkbox multi-select or programmed selection keys). Selection is persistent until cleared; table row hover may stack on top of it.
 _Avoid_: treating hover as selection, confusing sticky header chrome with selection
+
+### Legal content
+
+**Product**:
+A built-in product line code used on Legal Documents under Content. Create picks Product (and Kind) only from that catalog. This slice includes `facility-booking` and `portal`.
+_Avoid_: App, Operator-typed free-text Product codes
+
+**Legal Document**:
+The Portal-editable Markdown (per locale) for one Product and one Legal Document Kind, managed from one Legal Documents list under Content (for example `/content/legal-documents`). The list follows the usual DataPage soft-delete / recycle / restore pattern and may filter by Product or Kind. Save replaces the current wording. Body is Markdown only; no HTML editor and no image embed. Soft-delete is allowed under RBAC; delete confirmation must warn that public readers will not get that Product's Kind until restore. Create is only for a catalog Product × Kind with no row at all; if the pair sits in the recycle bin, create is rejected and the Operator restores instead. This slice does not add Portal Login or public legal pages in the admin SPA. Facility Booking is the Product that exposes public legal pages in this slice.
+_Avoid_: Content File, System Setting JSON, version history, acceptance tracking, WYSIWYG HTML, blocking delete in code because the row is built-in, creating while a soft-deleted twin exists
+
+**Legal Document Kind**:
+Terms of Service or Privacy Policy. Together with Product it identifies the row Operators edit. Each seeded Product ships both kinds. Member/public UI titles come from host i18n by Kind, not from an editable title on the row.
+_Avoid_: free-text type, one form that mixes both kinds into a single body, ToS-only admin UI, Operator-edited title as the Kind label
+
+**Terms of Service**:
+The Legal Document Kind for product terms of use.
+_Avoid_: using this name for Privacy Policy
+
+**Privacy Policy**:
+The Legal Document Kind for personal-information practices of that Product.
+_Avoid_: a subsection of Terms of Service

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -117,6 +117,11 @@ export const API_ENDPOINTS = {
       BULK_DELETE: `${ADMIN_API_PREFIX}/content/file/bulk`,
       ASSOCIATION_PREVIEW: `${ADMIN_API_PREFIX}/content/file/association-preview`,
     },
+    LEGAL_DOCUMENTS: {
+      PAGES: `${ADMIN_API_PREFIX}/content/legal-document/pages`,
+      DETAIL: (id: string) => `${ADMIN_API_PREFIX}/content/legal-document/${id}`,
+      UPDATE: (id: string) => `${ADMIN_API_PREFIX}/content/legal-document/${id}`,
+    },
   },
 
   // Facility booking (admin)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,8 @@ export * from "./services/orgService";
 export { default as orgService } from "./services/orgService";
 export * from "./services/fileService";
 export { default as fileService } from "./services/fileService";
+export * from "./services/legalDocumentService";
+export { default as legalDocumentService } from "./services/legalDocumentService";
 
 // Hooks
 export * from "./hooks/useApi";

--- a/src/api/services/legalDocumentService.ts
+++ b/src/api/services/legalDocumentService.ts
@@ -1,0 +1,60 @@
+import { API_ENDPOINTS, httpClient } from "@/api";
+
+export interface LegalDocumentTranslationItem {
+  localeId: string;
+  body: string;
+}
+
+export interface LegalDocumentUpdatePayload {
+  translations: LegalDocumentTranslationItem[];
+}
+
+export interface LegalDocumentItem {
+  id: string;
+  product: string;
+  kind: string;
+  createAt?: string | null;
+  createdBy?: string | null;
+  updateAt?: string | null;
+  updatedBy?: string | null;
+  deleteReason?: string | null;
+}
+
+export interface LegalDocumentDetail extends LegalDocumentItem {
+  translations: LegalDocumentTranslationItem[];
+}
+
+export interface LegalDocumentPagesParams {
+  page?: number;
+  page_size?: number;
+  order_by?: string;
+  descending?: boolean;
+  product?: string;
+  kind?: string;
+}
+
+export interface LegalDocumentPagesResponse {
+  page: number;
+  pageSize: number;
+  total: number;
+  items: LegalDocumentItem[];
+}
+
+export const legalDocumentService = {
+  async getPages(params: LegalDocumentPagesParams) {
+    return httpClient.get<LegalDocumentPagesResponse>(
+      API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.PAGES,
+      params as Record<string, unknown>
+    );
+  },
+
+  async getById(id: string) {
+    return httpClient.get<LegalDocumentDetail>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.DETAIL(id));
+  },
+
+  async update(id: string, payload: LegalDocumentUpdatePayload) {
+    return httpClient.put<LegalDocumentDetail>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.UPDATE(id), payload);
+  },
+};
+
+export default legalDocumentService;

--- a/src/const/enums.ts
+++ b/src/const/enums.ts
@@ -43,6 +43,7 @@ export enum Resource {
 
   // [content]
   ContentFile = "content:file",
+  ContentLegalDocument = "content:legal_document",
   ContentInstructor = "content:instructor",
   ContentLocation = "content:location",
   ContentTestimony = "content:testimony",

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -98,5 +98,41 @@
       "upload": "Upload",
       "uploadTitle": "Upload images"
     }
+  },
+  "legalDocument": {
+    "page": {
+      "title": "Legal Documents",
+      "description": "Edit localized Markdown for Product Terms of Service and Privacy Policy"
+    },
+    "table": {
+      "product": "Product",
+      "kind": "Kind",
+      "updatedAt": "Updated"
+    },
+    "product": {
+      "facility-booking": "Facility Booking",
+      "portal": "Portal"
+    },
+    "kind": {
+      "terms_of_service": "Terms of Service",
+      "privacy_policy": "Privacy Policy"
+    },
+    "search": {
+      "popoverTitle": "Filter Legal Documents",
+      "productLabel": "Product",
+      "kindLabel": "Kind",
+      "allProducts": "All products",
+      "allKinds": "All kinds",
+      "chipsTitle": "Active filters"
+    },
+    "modal": {
+      "editTitle": "Edit Legal Document"
+    },
+    "form": {
+      "product": "Product",
+      "kind": "Kind",
+      "body": "Markdown body",
+      "bodyHint": "Markdown only. HTML and image embeds are not supported."
+    }
   }
 }

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -98,5 +98,41 @@
       "upload": "上传",
       "uploadTitle": "上传图片"
     }
+  },
+  "legalDocument": {
+    "page": {
+      "title": "法律文件",
+      "description": "编辑各产品服务条款与隐私政策的多语言 Markdown"
+    },
+    "table": {
+      "product": "产品",
+      "kind": "类型",
+      "updatedAt": "更新时间"
+    },
+    "product": {
+      "facility-booking": "场地预约",
+      "portal": "Portal"
+    },
+    "kind": {
+      "terms_of_service": "服务条款",
+      "privacy_policy": "隐私政策"
+    },
+    "search": {
+      "popoverTitle": "筛选法律文件",
+      "productLabel": "产品",
+      "kindLabel": "类型",
+      "allProducts": "全部产品",
+      "allKinds": "全部类型",
+      "chipsTitle": "当前筛选"
+    },
+    "modal": {
+      "editTitle": "编辑法律文件"
+    },
+    "form": {
+      "product": "产品",
+      "kind": "类型",
+      "body": "Markdown 内容",
+      "bodyHint": "仅支持 Markdown，不支持 HTML 与图片嵌入。"
+    }
   }
 }

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -98,5 +98,41 @@
       "upload": "上傳",
       "uploadTitle": "上傳圖片"
     }
+  },
+  "legalDocument": {
+    "page": {
+      "title": "法律文件",
+      "description": "編輯各產品服務條款與隱私權政策的多語系 Markdown"
+    },
+    "table": {
+      "product": "產品",
+      "kind": "類型",
+      "updatedAt": "更新時間"
+    },
+    "product": {
+      "facility-booking": "場地預約",
+      "portal": "Portal"
+    },
+    "kind": {
+      "terms_of_service": "服務條款",
+      "privacy_policy": "隱私權政策"
+    },
+    "search": {
+      "popoverTitle": "篩選法律文件",
+      "productLabel": "產品",
+      "kindLabel": "類型",
+      "allProducts": "全部產品",
+      "allKinds": "全部類型",
+      "chipsTitle": "目前篩選"
+    },
+    "modal": {
+      "editTitle": "編輯法律文件"
+    },
+    "form": {
+      "product": "產品",
+      "kind": "類型",
+      "body": "Markdown 內容",
+      "bodyHint": "僅支援 Markdown，不支援 HTML 與圖片嵌入。"
+    }
   }
 }

--- a/src/pages/Content/LegalDocument/LegalDocumentDataForm.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDataForm.tsx
@@ -1,0 +1,109 @@
+import type { LegalDocumentDetail } from "@/api/services/legalDocumentService";
+import { useActiveLocales } from "@/hooks/useActiveLocales";
+import {
+  buildLegalDocumentUpdatePayload,
+  hydrateLegalDocumentTranslationMap,
+  type LegalDocumentTranslationMap,
+} from "@/pages/Content/LegalDocument/legalDocumentForm";
+import type { LegalDocumentUpdatePayload } from "@/api/services/legalDocumentService";
+import { localeTabLabel } from "@/utils/translationForm";
+import { Tabs, TextArea } from "@efcnewlife/newlife-ui";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface LegalDocumentDataFormHandle {
+  validate: () => boolean;
+  getValues: () => LegalDocumentUpdatePayload;
+}
+
+interface LegalDocumentDataFormProps {
+  document: LegalDocumentDetail;
+}
+
+const LegalDocumentDataForm = forwardRef<LegalDocumentDataFormHandle, LegalDocumentDataFormProps>(
+  function LegalDocumentDataForm({ document }, ref) {
+    const { t } = useTranslation("content");
+    const { t: tCommon } = useTranslation("common");
+    const { locales, defaultLocaleId, loading, error } = useActiveLocales();
+
+    const [translationMap, setTranslationMap] = useState<LegalDocumentTranslationMap>({});
+    const [activeTab, setActiveTab] = useState("");
+    const [errors, setErrors] = useState<{ body?: string }>({});
+
+    useEffect(() => {
+      if (locales.length === 0) return;
+      setTranslationMap(hydrateLegalDocumentTranslationMap(locales, document.translations));
+      setActiveTab(defaultLocaleId || locales[0]?.id || "");
+      setErrors({});
+    }, [document, defaultLocaleId, locales]);
+
+    const tabs = useMemo(
+      () =>
+        locales.map((locale) => ({
+          value: locale.id,
+          label: localeTabLabel(locale, locale.id === defaultLocaleId),
+        })),
+      [locales, defaultLocaleId]
+    );
+
+    const validate = (): boolean => {
+      if (!defaultLocaleId) {
+        setErrors({ body: tCommon("translation.defaultLocaleRequired") });
+        return false;
+      }
+      setErrors({});
+      return true;
+    };
+
+    useImperativeHandle(ref, () => ({
+      validate,
+      getValues: () => buildLegalDocumentUpdatePayload(translationMap),
+    }));
+
+    const activeBody = translationMap[activeTab]?.body ?? "";
+
+    return (
+      <div className="space-y-4">
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">{t("legalDocument.form.product")}</dt>
+            <dd className="mt-1 font-medium text-gray-800 dark:text-white/90">
+              {t(`legalDocument.product.${document.product}`, { defaultValue: document.product })}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">{t("legalDocument.form.kind")}</dt>
+            <dd className="mt-1 font-medium text-gray-800 dark:text-white/90">
+              {t(`legalDocument.kind.${document.kind}`, { defaultValue: document.kind })}
+            </dd>
+          </div>
+        </dl>
+
+        {loading ? <p className="text-sm text-gray-500">{tCommon("loading")}</p> : null}
+        {error ? <p className="text-sm text-error-500">{error}</p> : null}
+
+        {!loading && !error && locales.length > 0 ? (
+          <div className="space-y-3">
+            <Tabs tabs={tabs} value={activeTab} onChange={setActiveTab} label={tCommon("translation.tabsLabel")} />
+            <TextArea
+              id={`legal-document-body-${activeTab}`}
+              label={t("legalDocument.form.body")}
+              hint={t("legalDocument.form.bodyHint")}
+              value={activeBody}
+              onChange={(fieldValue) =>
+                setTranslationMap((prev) => ({
+                  ...prev,
+                  [activeTab]: { body: fieldValue },
+                }))
+              }
+              rows={16}
+              error={errors.body}
+            />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+export default LegalDocumentDataForm;

--- a/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
@@ -1,0 +1,268 @@
+import {
+  legalDocumentService,
+  type LegalDocumentDetail,
+  type LegalDocumentItem,
+} from "@/api/services/legalDocumentService";
+import type { DataTableColumn, MenuButtonType, PageButtonType, PopoverType } from "@/components/DataPage";
+import { CommonPageButton, CommonRowAction, DataPage } from "@/components/DataPage";
+import { Button, ModalForm, type ModalFormHandle } from "@efcnewlife/newlife-ui";
+import { PopoverPosition, Resource } from "@/const/enums";
+import { useModal } from "@/hooks/useModal";
+import LegalDocumentDataForm, {
+  type LegalDocumentDataFormHandle,
+} from "@/pages/Content/LegalDocument/LegalDocumentDataForm";
+import { isLegalDocumentKind, isLegalDocumentProduct } from "@/pages/Content/LegalDocument/legalDocumentForm";
+import LegalDocumentSearchPopover, {
+  type LegalDocumentSearchFilters,
+} from "@/pages/Content/LegalDocument/LegalDocumentSearchPopover";
+import type { ApiError } from "@/types/api";
+import { DateUtil } from "@/utils/dateUtil";
+import { notifyApiError, notifySuccess } from "@/utils/operationFeedback";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+type LegalDocumentRow = LegalDocumentItem & Record<string, unknown>;
+
+const LegalDocumentDataPage = () => {
+  const { t } = useTranslation("content");
+  const [items, setItems] = useState<LegalDocumentRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [orderBy, setOrderBy] = useState<string | undefined>();
+  const [descending, setDescending] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [searchFilters, setSearchFilters] = useState<LegalDocumentSearchFilters>({});
+  const [appliedFilters, setAppliedFilters] = useState<LegalDocumentSearchFilters>({});
+  const [editing, setEditing] = useState<LegalDocumentDetail | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const { isOpen: isFormOpen, openModal: openFormModal, closeModal: closeFormModal } = useModal(false);
+  const formRef = useRef<LegalDocumentDataFormHandle>(null);
+  const modalRef = useRef<ModalFormHandle>(null);
+  const clearSelectionRef = useRef<() => void>(() => {});
+
+  const productLabel = useCallback(
+    (value: string) => t(`legalDocument.product.${value}`, { defaultValue: value }),
+    [t]
+  );
+  const kindLabel = useCallback((value: string) => t(`legalDocument.kind.${value}`, { defaultValue: value }), [t]);
+
+  const fetchPages = useCallback(async () => {
+    clearSelectionRef.current?.();
+    setLoading(true);
+    try {
+      const res = await legalDocumentService.getPages({
+        page: currentPage - 1,
+        page_size: pageSize,
+        order_by: orderBy,
+        descending,
+        product: appliedFilters.product || undefined,
+        kind: appliedFilters.kind || undefined,
+      });
+      if (res.success) {
+        setItems((res.data.items || []) as LegalDocumentRow[]);
+        setTotal(res.data.total);
+        setCurrentPage((res.data.page ?? 0) + 1);
+      } else {
+        setItems([]);
+        setTotal(0);
+      }
+    } catch (error) {
+      notifyApiError(error, {
+        title: t("common:feedback.loadFailed"),
+        fallbackDescription: t("common:feedback.loadFailedDesc"),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [appliedFilters, currentPage, descending, orderBy, pageSize, t]);
+
+  useEffect(() => {
+    void fetchPages();
+  }, [fetchPages]);
+
+  const columns: DataTableColumn<LegalDocumentRow>[] = useMemo(
+    () => [
+      {
+        key: "product",
+        label: t("legalDocument.table.product"),
+        sortable: true,
+        width: "w-48",
+        render: (value) => productLabel(String(value || "")),
+      },
+      {
+        key: "kind",
+        label: t("legalDocument.table.kind"),
+        sortable: true,
+        width: "w-48",
+        render: (value) => kindLabel(String(value || "")),
+      },
+      {
+        key: "updateAt",
+        label: t("legalDocument.table.updatedAt"),
+        sortable: true,
+        width: "w-40",
+        render: (value) => (value ? DateUtil.format(value as string) : "—"),
+      },
+    ],
+    [kindLabel, productLabel, t]
+  );
+
+  const toolbarButtons: PageButtonType[] = useMemo(() => {
+    const searchPopoverCallback = ({
+      isOpen,
+      onOpenChange,
+      trigger,
+      popover,
+    }: {
+      isOpen: boolean;
+      onOpenChange: (open: boolean) => void;
+      trigger: React.ReactNode;
+      popover: PopoverType;
+    }) => (
+      <LegalDocumentSearchPopover
+        filters={searchFilters}
+        onFiltersChange={setSearchFilters}
+        onSearch={(filters) => {
+          setAppliedFilters({
+            product: filters.product && isLegalDocumentProduct(filters.product) ? filters.product : "",
+            kind: filters.kind && isLegalDocumentKind(filters.kind) ? filters.kind : "",
+          });
+          setCurrentPage(1);
+          onOpenChange(false);
+        }}
+        onClear={() => {
+          setSearchFilters({});
+          setAppliedFilters({});
+          setCurrentPage(1);
+          onOpenChange(false);
+        }}
+        trigger={trigger}
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        popover={popover}
+      />
+    );
+
+    return [
+      CommonPageButton.SEARCH(searchPopoverCallback, {
+        popover: {
+          title: t("legalDocument.search.popoverTitle"),
+          position: PopoverPosition.BottomLeft,
+          width: "420px",
+        },
+      }),
+      CommonPageButton.REFRESH(() => {
+        clearSelectionRef.current?.();
+        void fetchPages();
+      }),
+    ];
+  }, [fetchPages, searchFilters, t]);
+
+  const rowActions: MenuButtonType<LegalDocumentRow>[] = useMemo(
+    () => [
+      CommonRowAction.EDIT(async (row) => {
+        try {
+          const res = await legalDocumentService.getById(row.id);
+          if (res.success) {
+            setEditing(res.data);
+            openFormModal();
+          } else {
+            notifyApiError(
+              { code: 400, message: "" },
+              { title: t("common:feedback.loadFailed"), fallbackDescription: t("common:feedback.loadFailedDesc") }
+            );
+          }
+        } catch (error) {
+          notifyApiError(error, {
+            title: t("common:feedback.loadFailed"),
+            fallbackDescription: t("common:feedback.loadFailedDesc"),
+          });
+        }
+      }),
+    ],
+    [openFormModal, t]
+  );
+
+  return (
+    <>
+      <DataPage<LegalDocumentRow>
+        data={{ page: currentPage, pageSize, total, items }}
+        columns={columns}
+        loading={loading}
+        orderBy={orderBy}
+        descending={descending}
+        resource={Resource.ContentLegalDocument}
+        buttons={toolbarButtons}
+        rowActions={rowActions}
+        onSort={(key, desc) => {
+          setOrderBy(key || undefined);
+          setDescending(!!desc);
+        }}
+        onPageChange={setCurrentPage}
+        onItemsPerPageChange={(size) => {
+          setPageSize(size);
+          setCurrentPage(1);
+        }}
+        onClearSelectionRef={(fn) => {
+          clearSelectionRef.current = fn;
+        }}
+      />
+
+      <ModalForm
+        ref={modalRef}
+        title={t("legalDocument.modal.editTitle")}
+        isOpen={isFormOpen}
+        onClose={() => {
+          closeFormModal();
+          setEditing(null);
+        }}
+        className="max-w-3xl w-full mx-4 p-6"
+        footer={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                closeFormModal();
+                setEditing(null);
+              }}
+              disabled={submitting}
+            >
+              {t("common:cancel")}
+            </Button>
+            <Button variant="primary" size="sm" onClick={() => modalRef.current?.submit()} disabled={submitting}>
+              {t("common:save")}
+            </Button>
+          </>
+        }
+        onSubmit={async (e) => {
+          e.preventDefault();
+          if (!editing?.id || !formRef.current?.validate()) return;
+          const values = formRef.current.getValues();
+          setSubmitting(true);
+          try {
+            await legalDocumentService.update(editing.id, values);
+            notifySuccess({ title: t("common:feedback.updated") });
+            closeFormModal();
+            setEditing(null);
+            await fetchPages();
+          } catch (error) {
+            const apiError = error as ApiError;
+            notifyApiError(apiError ?? error, {
+              title: t("common:feedback.saveFailed"),
+              fallbackDescription: t("common:feedback.saveFailedDesc"),
+            });
+          } finally {
+            setSubmitting(false);
+          }
+        }}
+      >
+        {editing ? <LegalDocumentDataForm ref={formRef} document={editing} /> : null}
+      </ModalForm>
+    </>
+  );
+};
+
+export default LegalDocumentDataPage;

--- a/src/pages/Content/LegalDocument/LegalDocumentManagement.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentManagement.tsx
@@ -1,0 +1,14 @@
+import ManagementPage from "@/components/common/ManagementPage";
+import LegalDocumentDataPage from "@/pages/Content/LegalDocument/LegalDocumentDataPage";
+import { useTranslation } from "react-i18next";
+
+const LegalDocumentManagement = () => {
+  const { t } = useTranslation("content");
+  return (
+    <ManagementPage title={t("legalDocument.page.title")} description={t("legalDocument.page.description")}>
+      <LegalDocumentDataPage />
+    </ManagementPage>
+  );
+};
+
+export default LegalDocumentManagement;

--- a/src/pages/Content/LegalDocument/LegalDocumentSearchPopover.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentSearchPopover.tsx
@@ -1,0 +1,116 @@
+import { PopoverType } from "@/components/DataPage";
+import SearchPopoverContent from "@/components/DataPage/SearchPopoverContent";
+import {
+  LEGAL_DOCUMENT_KINDS,
+  LEGAL_DOCUMENT_PRODUCTS,
+  type LegalDocumentKind,
+  type LegalDocumentProduct,
+} from "@/pages/Content/LegalDocument/legalDocumentForm";
+import { Select } from "@efcnewlife/newlife-ui";
+import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface LegalDocumentSearchFilters {
+  product?: LegalDocumentProduct | "";
+  kind?: LegalDocumentKind | "";
+}
+
+interface LegalDocumentSearchPopoverProps {
+  filters: LegalDocumentSearchFilters;
+  onFiltersChange: (filters: LegalDocumentSearchFilters) => void;
+  onSearch: (filters: LegalDocumentSearchFilters) => void;
+  onClear: () => void;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: ReactNode;
+  popover: PopoverType;
+}
+
+const LegalDocumentSearchPopover: React.FC<LegalDocumentSearchPopoverProps> = ({
+  filters,
+  onFiltersChange,
+  onSearch,
+  onClear,
+  isOpen,
+  onOpenChange,
+  trigger,
+  popover,
+}) => {
+  const { t } = useTranslation("content");
+
+  const productOptions = [
+    { value: "", label: t("legalDocument.search.allProducts") },
+    ...LEGAL_DOCUMENT_PRODUCTS.map((value) => ({
+      value,
+      label: t(`legalDocument.product.${value}`),
+    })),
+  ];
+
+  const kindOptions = [
+    { value: "", label: t("legalDocument.search.allKinds") },
+    ...LEGAL_DOCUMENT_KINDS.map((value) => ({
+      value,
+      label: t(`legalDocument.kind.${value}`),
+    })),
+  ];
+
+  const chips: string[] = [];
+  if (filters.product) chips.push(t(`legalDocument.product.${filters.product}`));
+  if (filters.kind) chips.push(t(`legalDocument.kind.${filters.kind}`));
+
+  return (
+    <SearchPopoverContent
+      onSearch={() => onSearch(filters)}
+      onClear={onClear}
+      trigger={trigger}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      popover={popover}
+    >
+      <div className="space-y-4">
+        <Select
+          id="legal-document-search-product"
+          label={t("legalDocument.search.productLabel")}
+          value={filters.product || ""}
+          onChange={(value) =>
+            onFiltersChange({
+              ...filters,
+              product: (value ? String(value) : "") as LegalDocumentProduct | "",
+            })
+          }
+          options={productOptions}
+        />
+        <Select
+          id="legal-document-search-kind"
+          label={t("legalDocument.search.kindLabel")}
+          value={filters.kind || ""}
+          onChange={(value) =>
+            onFiltersChange({
+              ...filters,
+              kind: (value ? String(value) : "") as LegalDocumentKind | "",
+            })
+          }
+          options={kindOptions}
+        />
+
+        {chips.length > 0 ? (
+          <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">{t("legalDocument.search.chipsTitle")}</div>
+            <div className="flex flex-wrap gap-1">
+              {chips.map((label) => (
+                <span
+                  key={label}
+                  className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </SearchPopoverContent>
+  );
+};
+
+export default LegalDocumentSearchPopover;

--- a/src/pages/Content/LegalDocument/legalDocumentForm.test.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEGAL_DOCUMENT_KINDS,
+  LEGAL_DOCUMENT_PRODUCTS,
+  buildLegalDocumentUpdatePayload,
+  createEmptyLegalDocumentTranslationMap,
+  hydrateLegalDocumentTranslationMap,
+  isLegalDocumentKind,
+  isLegalDocumentProduct,
+} from "./legalDocumentForm";
+
+describe("legal document catalog", () => {
+  it("lists built-in Product and Kind codes for this slice", () => {
+    expect(LEGAL_DOCUMENT_PRODUCTS).toEqual(["facility-booking", "portal"]);
+    expect(LEGAL_DOCUMENT_KINDS).toEqual(["terms_of_service", "privacy_policy"]);
+  });
+
+  it("accepts only catalog Product and Kind codes", () => {
+    expect(isLegalDocumentProduct("facility-booking")).toBe(true);
+    expect(isLegalDocumentProduct("portal")).toBe(true);
+    expect(isLegalDocumentProduct("unknown")).toBe(false);
+    expect(isLegalDocumentKind("terms_of_service")).toBe(true);
+    expect(isLegalDocumentKind("privacy_policy")).toBe(true);
+    expect(isLegalDocumentKind("tos")).toBe(false);
+  });
+});
+
+describe("legal document translation map", () => {
+  const locales = [
+    {
+      id: "locale-en",
+      languageCode: "en",
+      name: "English",
+      isDefault: true,
+      isActive: true,
+    },
+    {
+      id: "locale-tw",
+      languageCode: "zh",
+      regionCode: "TW",
+      name: "Traditional Chinese",
+      isDefault: false,
+      isActive: true,
+    },
+  ];
+
+  it("creates an empty body per active locale", () => {
+    expect(createEmptyLegalDocumentTranslationMap(locales)).toEqual({
+      "locale-en": { body: "" },
+      "locale-tw": { body: "" },
+    });
+  });
+
+  it("hydrates bodies from existing translations and keeps missing locales empty", () => {
+    const map = hydrateLegalDocumentTranslationMap(locales, [
+      { localeId: "locale-en", body: "# Terms" },
+      { localeId: "locale-missing", body: "ignored" },
+    ]);
+
+    expect(map).toEqual({
+      "locale-en": { body: "# Terms" },
+      "locale-tw": { body: "" },
+    });
+  });
+
+  it("builds an update payload for every locale, including empty Markdown bodies", () => {
+    const payload = buildLegalDocumentUpdatePayload({
+      "locale-en": { body: "  Hello  " },
+      "locale-tw": { body: "" },
+    });
+
+    expect(payload).toEqual({
+      translations: [
+        { localeId: "locale-en", body: "  Hello  " },
+        { localeId: "locale-tw", body: "" },
+      ],
+    });
+  });
+});

--- a/src/pages/Content/LegalDocument/legalDocumentForm.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.ts
@@ -1,0 +1,50 @@
+import type { LocaleItem } from "@/api/services/localeService";
+import type { LegalDocumentTranslationItem, LegalDocumentUpdatePayload } from "@/api/services/legalDocumentService";
+
+export const LEGAL_DOCUMENT_PRODUCTS = ["facility-booking", "portal"] as const;
+export const LEGAL_DOCUMENT_KINDS = ["terms_of_service", "privacy_policy"] as const;
+
+export type LegalDocumentProduct = (typeof LEGAL_DOCUMENT_PRODUCTS)[number];
+export type LegalDocumentKind = (typeof LEGAL_DOCUMENT_KINDS)[number];
+
+export interface LegalDocumentTranslationFields {
+  body: string;
+}
+
+export type LegalDocumentTranslationMap = Record<string, LegalDocumentTranslationFields>;
+
+export type { LegalDocumentTranslationItem, LegalDocumentUpdatePayload };
+
+export const isLegalDocumentProduct = (value: string): value is LegalDocumentProduct =>
+  (LEGAL_DOCUMENT_PRODUCTS as readonly string[]).includes(value);
+
+export const isLegalDocumentKind = (value: string): value is LegalDocumentKind =>
+  (LEGAL_DOCUMENT_KINDS as readonly string[]).includes(value);
+
+export const createEmptyLegalDocumentTranslationMap = (locales: LocaleItem[]): LegalDocumentTranslationMap =>
+  locales.reduce<LegalDocumentTranslationMap>((acc, locale) => {
+    acc[locale.id] = { body: "" };
+    return acc;
+  }, {});
+
+export const hydrateLegalDocumentTranslationMap = (
+  locales: LocaleItem[],
+  existingTranslations?: LegalDocumentTranslationItem[]
+): LegalDocumentTranslationMap => {
+  const map = createEmptyLegalDocumentTranslationMap(locales);
+  if (!existingTranslations?.length) return map;
+
+  for (const item of existingTranslations) {
+    if (map[item.localeId]) {
+      map[item.localeId] = { body: item.body ?? "" };
+    }
+  }
+  return map;
+};
+
+export const buildLegalDocumentUpdatePayload = (map: LegalDocumentTranslationMap): LegalDocumentUpdatePayload => ({
+  translations: Object.entries(map).map(([localeId, fields]) => ({
+    localeId,
+    body: fields.body ?? "",
+  })),
+});

--- a/src/routes/modules/Content/content.tsx
+++ b/src/routes/modules/Content/content.tsx
@@ -1,4 +1,5 @@
 import FileManagement from "@/pages/Content/File/FileManagement";
+import LegalDocumentManagement from "@/pages/Content/LegalDocument/LegalDocumentManagement";
 import { AppRoute } from "@/types/route";
 
 export const contentRoutes: AppRoute[] = [
@@ -10,6 +11,16 @@ export const contentRoutes: AppRoute[] = [
       description: "Content file management",
       requiresAuth: true,
       breadcrumb: ["Content", "Files"],
+    },
+  },
+  {
+    path: "/content/legal-documents",
+    element: <LegalDocumentManagement />,
+    meta: {
+      title: "Legal Documents",
+      description: "Content Legal Document management",
+      requiresAuth: true,
+      breadcrumb: ["Content", "Legal Documents"],
     },
   },
 ];

--- a/src/utils/component-registry.tsx
+++ b/src/utils/component-registry.tsx
@@ -11,6 +11,7 @@ import MinistryMemberManagement from "@/pages/Ministry/MinistryMember/MinistryMe
 import MinistryApprovalManagement from "@/pages/Ministry/Approval/MinistryApprovalManagement";
 import PersonManagement from "@/pages/Member/Person/PersonManagement";
 import FileManagement from "@/pages/Content/File/FileManagement";
+import LegalDocumentManagement from "@/pages/Content/LegalDocument/LegalDocumentManagement";
 import PositionManagement from "@/pages/Org/Position/PositionManagement";
 import PermissionManagement from "@/pages/System/Permission/PermissionManagement";
 import ResourceManagement from "@/pages/System/Resource/ResourceManagement";
@@ -48,6 +49,7 @@ const componentRegistry: Record<string, React.ComponentType> = {
   MEMBER_PERSON: PersonManagement,
   // Content
   CONTENT_FILE: FileManagement,
+  CONTENT_LEGAL_DOCUMENT: LegalDocumentManagement,
 };
 
 function normalizeKey(key: string): string {


### PR DESCRIPTION
## Summary

Add the Content → Legal Documents admin page so operators can list seeded Product × Kind rows, filter by Product/Kind, and edit per-locale Markdown via the admin API. Menu key `CONTENT_LEGAL_DOCUMENT` resolves to the real page (not Blank).

Closes #46

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Route `/content/legal-documents` + `component-registry` key `CONTENT_LEGAL_DOCUMENT` (matches Core API RBAC seed).
- DataPage list with Product/Kind columns and search filters; edit modal uses translation tabs + Markdown `TextArea` only (no WYSIWYG/HTML/image embed).
- Product and Kind labels come from i18n (`en` / `zh-TW` / `zh-CN`); not editable title fields.
- API via `legalDocumentService` + `API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS`; Operation feedback uses existing toast helpers.
- Intentionally out of scope for this ticket: create, soft-delete risk modal, restore, Portal Login, and public legal pages.

## Testing

- [x] `pnpm run format:check`
- [x] `pnpm run type-check`
- [x] `pnpm run test`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge