### PR TITLE
feat: Legal Document create, soft-delete warning, and restore (#47)

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -119,8 +119,11 @@ export const API_ENDPOINTS = {
     },
     LEGAL_DOCUMENTS: {
       PAGES: `${ADMIN_API_PREFIX}/content/legal-document/pages`,
+      CREATE: `${ADMIN_API_PREFIX}/content/legal-document`,
       DETAIL: (id: string) => `${ADMIN_API_PREFIX}/content/legal-document/${id}`,
       UPDATE: (id: string) => `${ADMIN_API_PREFIX}/content/legal-document/${id}`,
+      DELETE: (id: string) => `${ADMIN_API_PREFIX}/content/legal-document/${id}`,
+      RESTORE: `${ADMIN_API_PREFIX}/content/legal-document/restore`,
     },
   },
 

--- a/src/api/services/legalDocumentService.ts
+++ b/src/api/services/legalDocumentService.ts
@@ -67,7 +67,7 @@ export const legalDocumentService = {
   },
 
   async delete(id: string, payload: { reason?: string; permanent?: boolean }) {
-    return httpClient.delete<void>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.DELETE(id), { data: payload });
+    return httpClient.delete<void>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.DELETE(id), payload);
   },
 
   async restore(ids: string[]) {

--- a/src/api/services/legalDocumentService.ts
+++ b/src/api/services/legalDocumentService.ts
@@ -5,6 +5,11 @@ export interface LegalDocumentTranslationItem {
   body: string;
 }
 
+export interface LegalDocumentCreatePayload {
+  product: string;
+  kind: string;
+}
+
 export interface LegalDocumentUpdatePayload {
   translations: LegalDocumentTranslationItem[];
 }
@@ -29,6 +34,7 @@ export interface LegalDocumentPagesParams {
   page_size?: number;
   order_by?: string;
   descending?: boolean;
+  deleted?: boolean;
   product?: string;
   kind?: string;
 }
@@ -52,8 +58,20 @@ export const legalDocumentService = {
     return httpClient.get<LegalDocumentDetail>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.DETAIL(id));
   },
 
+  async create(payload: LegalDocumentCreatePayload) {
+    return httpClient.post<{ id: string }>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.CREATE, payload);
+  },
+
   async update(id: string, payload: LegalDocumentUpdatePayload) {
     return httpClient.put<LegalDocumentDetail>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.UPDATE(id), payload);
+  },
+
+  async delete(id: string, payload: { reason?: string; permanent?: boolean }) {
+    return httpClient.delete<void>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.DELETE(id), { data: payload });
+  },
+
+  async restore(ids: string[]) {
+    return httpClient.put<void>(API_ENDPOINTS.CONTENT.LEGAL_DOCUMENTS.RESTORE, { ids });
   },
 };
 

--- a/src/components/DataPage/DeleteForm.tsx
+++ b/src/components/DataPage/DeleteForm.tsx
@@ -8,6 +8,8 @@ interface DeleteFormProps {
   submitting?: boolean;
   entityName?: string;
   isPermanent?: boolean;
+  /** Soft-delete warning body; defaults to common soft-delete warning with entityName. */
+  softWarningBody?: string;
 }
 
 const DeleteForm: React.FC<DeleteFormProps> = ({
@@ -16,6 +18,7 @@ const DeleteForm: React.FC<DeleteFormProps> = ({
   submitting,
   entityName = "material",
   isPermanent = false,
+  softWarningBody,
 }) => {
   const { t } = useTranslation();
   const [reason, setReason] = useState("");
@@ -60,7 +63,7 @@ const DeleteForm: React.FC<DeleteFormProps> = ({
               {isPermanent ? (
                 <p>{t("common:forms.delete.warningBodyPermanent", { entityName })}</p>
               ) : (
-                <p>{t("common:forms.delete.warningBodySoft", { entityName })}</p>
+                <p>{softWarningBody ?? t("common:forms.delete.warningBodySoft", { entityName })}</p>
               )}
             </div>
           </div>

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -126,13 +126,28 @@
       "chipsTitle": "Active filters"
     },
     "modal": {
+      "createTitle": "Create Legal Document",
       "editTitle": "Edit Legal Document"
     },
     "form": {
       "product": "Product",
       "kind": "Kind",
+      "productPlaceholder": "Select a product",
+      "kindPlaceholder": "Select a kind",
+      "productRequired": "Product is required",
+      "kindRequired": "Kind is required",
+      "createHint": "Choose a built-in Product and Kind. Markdown is edited after create.",
       "body": "Markdown body",
       "bodyHint": "Markdown only. HTML and image embeds are not supported."
+    },
+    "deleteForm": {
+      "entityLabel": "Legal Document",
+      "publicReadWarning": "Public readers will not receive this Product's Kind until you restore the document from recycle."
+    },
+    "errors": {
+      "exists": "A Legal Document for this Product and Kind already exists",
+      "inRecycleBin": "This Product and Kind exist in recycle; restore them instead of creating again",
+      "notFound": "Legal Document was not found"
     }
   }
 }

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -126,13 +126,28 @@
       "chipsTitle": "当前筛选"
     },
     "modal": {
+      "createTitle": "新增法律文件",
       "editTitle": "编辑法律文件"
     },
     "form": {
       "product": "产品",
       "kind": "类型",
+      "productPlaceholder": "选择产品",
+      "kindPlaceholder": "选择类型",
+      "productRequired": "请选择产品",
+      "kindRequired": "请选择类型",
+      "createHint": "仅能从内置产品与类型创建；Markdown 请在创建后编辑。",
       "body": "Markdown 内容",
       "bodyHint": "仅支持 Markdown，不支持 HTML 与图片嵌入。"
+    },
+    "deleteForm": {
+      "entityLabel": "法律文件",
+      "publicReadWarning": "公开读者在还原前将无法取得此产品的该类文件，请确认后再软删除。"
+    },
+    "errors": {
+      "exists": "此产品与类型的法律文件已存在",
+      "inRecycleBin": "此产品与类型已在回收站，请还原，勿重新创建",
+      "notFound": "找不到法律文件"
     }
   }
 }

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -126,13 +126,28 @@
       "chipsTitle": "目前篩選"
     },
     "modal": {
+      "createTitle": "新增法律文件",
       "editTitle": "編輯法律文件"
     },
     "form": {
       "product": "產品",
       "kind": "類型",
+      "productPlaceholder": "選擇產品",
+      "kindPlaceholder": "選擇類型",
+      "productRequired": "請選擇產品",
+      "kindRequired": "請選擇類型",
+      "createHint": "僅能從內建產品與類型建立；Markdown 請於建立後編輯。",
       "body": "Markdown 內容",
       "bodyHint": "僅支援 Markdown，不支援 HTML 與圖片嵌入。"
+    },
+    "deleteForm": {
+      "entityLabel": "法律文件",
+      "publicReadWarning": "公開讀者在還原前將無法取得此產品的該類文件，請確認後再軟刪除。"
+    },
+    "errors": {
+      "exists": "此產品與類型的法律文件已存在",
+      "inRecycleBin": "此產品與類型已在回收桶，請還原，勿重新建立",
+      "notFound": "找不到法律文件"
     }
   }
 }

--- a/src/pages/Content/LegalDocument/LegalDocumentCreateForm.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentCreateForm.tsx
@@ -1,0 +1,89 @@
+import {
+  buildLegalDocumentCreatePayload,
+  isLegalDocumentKind,
+  isLegalDocumentProduct,
+  LEGAL_DOCUMENT_KINDS,
+  LEGAL_DOCUMENT_PRODUCTS,
+  type LegalDocumentCreatePayload,
+  type LegalDocumentKind,
+  type LegalDocumentProduct,
+} from "@/pages/Content/LegalDocument/legalDocumentForm";
+import { Select } from "@efcnewlife/newlife-ui";
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface LegalDocumentCreateFormHandle {
+  validate: () => boolean;
+  getValues: () => LegalDocumentCreatePayload | null;
+}
+
+const LegalDocumentCreateForm = forwardRef<LegalDocumentCreateFormHandle>(
+  function LegalDocumentCreateForm(_props, ref) {
+    const { t } = useTranslation("content");
+    const [product, setProduct] = useState<LegalDocumentProduct | "">("");
+    const [kind, setKind] = useState<LegalDocumentKind | "">("");
+    const [errors, setErrors] = useState<{ product?: string; kind?: string }>({});
+
+    const productOptions = LEGAL_DOCUMENT_PRODUCTS.map((value) => ({
+      value,
+      label: t(`legalDocument.product.${value}`),
+    }));
+
+    const kindOptions = LEGAL_DOCUMENT_KINDS.map((value) => ({
+      value,
+      label: t(`legalDocument.kind.${value}`),
+    }));
+
+    useImperativeHandle(ref, () => ({
+      validate: () => {
+        const nextErrors: { product?: string; kind?: string } = {};
+        if (!product) {
+          nextErrors.product = t("legalDocument.form.productRequired");
+        }
+        if (!kind) {
+          nextErrors.kind = t("legalDocument.form.kindRequired");
+        }
+        setErrors(nextErrors);
+        return Object.keys(nextErrors).length === 0;
+      },
+      getValues: () => {
+        if (!product || !kind) return null;
+        return buildLegalDocumentCreatePayload(product, kind);
+      },
+    }));
+
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600 dark:text-gray-300">{t("legalDocument.form.createHint")}</p>
+        <Select
+          id="legal-document-create-product"
+          label={t("legalDocument.form.product")}
+          value={product}
+          onChange={(value) => {
+            const next = value ? String(value) : "";
+            setProduct(isLegalDocumentProduct(next) ? next : "");
+            setErrors((prev) => ({ ...prev, product: undefined }));
+          }}
+          options={productOptions}
+          placeholder={t("legalDocument.form.productPlaceholder")}
+          error={errors.product}
+        />
+        <Select
+          id="legal-document-create-kind"
+          label={t("legalDocument.form.kind")}
+          value={kind}
+          onChange={(value) => {
+            const next = value ? String(value) : "";
+            setKind(isLegalDocumentKind(next) ? next : "");
+            setErrors((prev) => ({ ...prev, kind: undefined }));
+          }}
+          options={kindOptions}
+          placeholder={t("legalDocument.form.kindPlaceholder")}
+          error={errors.kind}
+        />
+      </div>
+    );
+  }
+);
+
+export default LegalDocumentCreateForm;

--- a/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
@@ -5,13 +5,19 @@ import {
 } from "@/api/services/legalDocumentService";
 import type { DataTableColumn, MenuButtonType, PageButtonType, PopoverType } from "@/components/DataPage";
 import { CommonPageButton, CommonRowAction, DataPage } from "@/components/DataPage";
-import { Button, ModalForm, type ModalFormHandle } from "@efcnewlife/newlife-ui";
+import { getRecycleButtonClassName } from "@/components/DataPage/PageButtonTypes";
+import { Button, Modal, ModalForm, type ModalFormHandle } from "@efcnewlife/newlife-ui";
 import { PopoverPosition, Resource } from "@/const/enums";
 import { useModal } from "@/hooks/useModal";
+import LegalDocumentCreateForm, {
+  type LegalDocumentCreateFormHandle,
+} from "@/pages/Content/LegalDocument/LegalDocumentCreateForm";
 import LegalDocumentDataForm, {
   type LegalDocumentDataFormHandle,
 } from "@/pages/Content/LegalDocument/LegalDocumentDataForm";
+import LegalDocumentDeleteForm from "@/pages/Content/LegalDocument/LegalDocumentDeleteForm";
 import { isLegalDocumentKind, isLegalDocumentProduct } from "@/pages/Content/LegalDocument/legalDocumentForm";
+import { resolveLegalDocumentSaveErrorMessage } from "@/pages/Content/LegalDocument/legalDocumentSaveError";
 import LegalDocumentSearchPopover, {
   type LegalDocumentSearchFilters,
 } from "@/pages/Content/LegalDocument/LegalDocumentSearchPopover";
@@ -32,13 +38,18 @@ const LegalDocumentDataPage = () => {
   const [orderBy, setOrderBy] = useState<string | undefined>();
   const [descending, setDescending] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [showDeleted, setShowDeleted] = useState(false);
   const [searchFilters, setSearchFilters] = useState<LegalDocumentSearchFilters>({});
   const [appliedFilters, setAppliedFilters] = useState<LegalDocumentSearchFilters>({});
+  const [formMode, setFormMode] = useState<"create" | "edit">("create");
   const [editing, setEditing] = useState<LegalDocumentDetail | null>(null);
+  const [deleting, setDeleting] = useState<LegalDocumentRow | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const { isOpen: isFormOpen, openModal: openFormModal, closeModal: closeFormModal } = useModal(false);
-  const formRef = useRef<LegalDocumentDataFormHandle>(null);
+  const { isOpen: isDeleteOpen, openModal: openDeleteModal, closeModal: closeDeleteModal } = useModal(false);
+  const editFormRef = useRef<LegalDocumentDataFormHandle>(null);
+  const createFormRef = useRef<LegalDocumentCreateFormHandle>(null);
   const modalRef = useRef<ModalFormHandle>(null);
   const clearSelectionRef = useRef<() => void>(() => {});
 
@@ -57,6 +68,7 @@ const LegalDocumentDataPage = () => {
         page_size: pageSize,
         order_by: orderBy,
         descending,
+        deleted: showDeleted || undefined,
         product: appliedFilters.product || undefined,
         kind: appliedFilters.kind || undefined,
       });
@@ -76,7 +88,7 @@ const LegalDocumentDataPage = () => {
     } finally {
       setLoading(false);
     }
-  }, [appliedFilters, currentPage, descending, orderBy, pageSize, t]);
+  }, [appliedFilters, currentPage, descending, orderBy, pageSize, showDeleted, t]);
 
   useEffect(() => {
     void fetchPages();
@@ -153,37 +165,92 @@ const LegalDocumentDataPage = () => {
           width: "420px",
         },
       }),
+      CommonPageButton.ADD(
+        () => {
+          setFormMode("create");
+          setEditing(null);
+          openFormModal();
+        },
+        { visible: !showDeleted }
+      ),
       CommonPageButton.REFRESH(() => {
         clearSelectionRef.current?.();
         void fetchPages();
       }),
+      CommonPageButton.RECYCLE(
+        () => {
+          setShowDeleted((value) => !value);
+          setCurrentPage(1);
+        },
+        { className: getRecycleButtonClassName(showDeleted) }
+      ),
     ];
-  }, [fetchPages, searchFilters, t]);
+  }, [fetchPages, openFormModal, searchFilters, showDeleted, t]);
 
   const rowActions: MenuButtonType<LegalDocumentRow>[] = useMemo(
     () => [
-      CommonRowAction.EDIT(async (row) => {
-        try {
-          const res = await legalDocumentService.getById(row.id);
-          if (res.success) {
-            setEditing(res.data);
-            openFormModal();
-          } else {
-            notifyApiError(
-              { code: 400, message: "" },
-              { title: t("common:feedback.loadFailed"), fallbackDescription: t("common:feedback.loadFailedDesc") }
-            );
+      CommonRowAction.EDIT(
+        async (row) => {
+          try {
+            const res = await legalDocumentService.getById(row.id);
+            if (res.success) {
+              setFormMode("edit");
+              setEditing(res.data);
+              openFormModal();
+            } else {
+              notifyApiError(
+                { code: 400, message: "" },
+                { title: t("common:feedback.loadFailed"), fallbackDescription: t("common:feedback.loadFailedDesc") }
+              );
+            }
+          } catch (error) {
+            notifyApiError(error, {
+              title: t("common:feedback.loadFailed"),
+              fallbackDescription: t("common:feedback.loadFailedDesc"),
+            });
           }
-        } catch (error) {
-          notifyApiError(error, {
-            title: t("common:feedback.loadFailed"),
-            fallbackDescription: t("common:feedback.loadFailedDesc"),
-          });
+        },
+        { visible: () => !showDeleted }
+      ),
+      CommonRowAction.RESTORE(
+        async (row) => {
+          try {
+            setSubmitting(true);
+            await legalDocumentService.restore([row.id]);
+            notifySuccess({ title: t("common:feedback.restored") });
+            await fetchPages();
+          } catch (error) {
+            const apiError = error as ApiError;
+            notifyApiError(apiError ?? error, {
+              title: t("common:feedback.actionFailed"),
+              fallbackDescription: t("common:feedback.actionFailedDesc"),
+              resolveDescription: (err) => resolveLegalDocumentSaveErrorMessage(err, t),
+            });
+          } finally {
+            setSubmitting(false);
+          }
+        },
+        { visible: () => showDeleted }
+      ),
+      CommonRowAction.DELETE(
+        (row) => {
+          setDeleting(row);
+          openDeleteModal();
+        },
+        {
+          text: showDeleted ? t("common:deletePermanently") : t("common:delete"),
+          visible: true,
         }
-      }),
+      ),
     ],
-    [openFormModal, t]
+    [fetchPages, openDeleteModal, openFormModal, showDeleted, t]
   );
+
+  const closeForm = () => {
+    closeFormModal();
+    setEditing(null);
+    setFormMode("create");
+  };
 
   return (
     <>
@@ -212,24 +279,13 @@ const LegalDocumentDataPage = () => {
 
       <ModalForm
         ref={modalRef}
-        title={t("legalDocument.modal.editTitle")}
+        title={formMode === "create" ? t("legalDocument.modal.createTitle") : t("legalDocument.modal.editTitle")}
         isOpen={isFormOpen}
-        onClose={() => {
-          closeFormModal();
-          setEditing(null);
-        }}
+        onClose={closeForm}
         className="max-w-3xl w-full mx-4 p-6"
         footer={
           <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                closeFormModal();
-                setEditing(null);
-              }}
-              disabled={submitting}
-            >
+            <Button variant="outline" size="sm" onClick={closeForm} disabled={submitting}>
               {t("common:cancel")}
             </Button>
             <Button variant="primary" size="sm" onClick={() => modalRef.current?.submit()} disabled={submitting}>
@@ -239,28 +295,97 @@ const LegalDocumentDataPage = () => {
         }
         onSubmit={async (e) => {
           e.preventDefault();
-          if (!editing?.id || !formRef.current?.validate()) return;
-          const values = formRef.current.getValues();
+          if (formMode === "create") {
+            if (!createFormRef.current?.validate()) return;
+            const values = createFormRef.current.getValues();
+            if (!values) return;
+            setSubmitting(true);
+            try {
+              await legalDocumentService.create(values);
+              notifySuccess({ title: t("common:feedback.created") });
+              closeForm();
+              await fetchPages();
+            } catch (error) {
+              const apiError = error as ApiError;
+              notifyApiError(apiError ?? error, {
+                title: t("common:feedback.saveFailed"),
+                fallbackDescription: t("common:feedback.saveFailedDesc"),
+                resolveDescription: (err) => resolveLegalDocumentSaveErrorMessage(err, t),
+              });
+            } finally {
+              setSubmitting(false);
+            }
+            return;
+          }
+
+          if (!editing?.id || !editFormRef.current?.validate()) return;
+          const values = editFormRef.current.getValues();
           setSubmitting(true);
           try {
             await legalDocumentService.update(editing.id, values);
             notifySuccess({ title: t("common:feedback.updated") });
-            closeFormModal();
-            setEditing(null);
+            closeForm();
             await fetchPages();
           } catch (error) {
             const apiError = error as ApiError;
             notifyApiError(apiError ?? error, {
               title: t("common:feedback.saveFailed"),
               fallbackDescription: t("common:feedback.saveFailedDesc"),
+              resolveDescription: (err) => resolveLegalDocumentSaveErrorMessage(err, t),
             });
           } finally {
             setSubmitting(false);
           }
         }}
       >
-        {editing ? <LegalDocumentDataForm ref={formRef} document={editing} /> : null}
+        {formMode === "create" && isFormOpen ? (
+          <LegalDocumentCreateForm key="legal-document-create" ref={createFormRef} />
+        ) : editing ? (
+          <LegalDocumentDataForm ref={editFormRef} document={editing} />
+        ) : null}
       </ModalForm>
+
+      <Modal
+        isOpen={isDeleteOpen}
+        onClose={() => {
+          closeDeleteModal();
+          setDeleting(null);
+        }}
+        className="max-w-[600px] p-5 lg:p-10"
+        showCloseButton={false}
+      >
+        <LegalDocumentDeleteForm
+          isPermanent={showDeleted}
+          submitting={submitting}
+          onCancel={() => {
+            closeDeleteModal();
+            setDeleting(null);
+          }}
+          onSubmit={async (payload) => {
+            if (!deleting?.id) return;
+            setSubmitting(true);
+            try {
+              await legalDocumentService.delete(deleting.id, {
+                reason: payload.reason,
+                permanent: payload.permanent ?? showDeleted,
+              });
+              notifySuccess({ title: t("common:feedback.deleted") });
+              closeDeleteModal();
+              setDeleting(null);
+              await fetchPages();
+            } catch (error) {
+              const apiError = error as ApiError;
+              notifyApiError(apiError ?? error, {
+                title: t("common:feedback.deleteFailed"),
+                fallbackDescription: t("common:feedback.deleteFailedDesc"),
+                resolveDescription: (err) => resolveLegalDocumentSaveErrorMessage(err, t),
+              });
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        />
+      </Modal>
     </>
   );
 };

--- a/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
@@ -6,7 +6,6 @@ import {
 import type { DataTableColumn, MenuButtonType, PageButtonType, PopoverType } from "@/components/DataPage";
 import { CommonPageButton, CommonRowAction, DataPage } from "@/components/DataPage";
 import { getRecycleButtonClassName } from "@/components/DataPage/PageButtonTypes";
-import { Button, Modal, ModalForm, type ModalFormHandle } from "@efcnewlife/newlife-ui";
 import { PopoverPosition, Resource } from "@/const/enums";
 import { useModal } from "@/hooks/useModal";
 import LegalDocumentCreateForm, {
@@ -24,6 +23,7 @@ import LegalDocumentSearchPopover, {
 import type { ApiError } from "@/types/api";
 import { DateUtil } from "@/utils/dateUtil";
 import { notifyApiError, notifySuccess } from "@/utils/operationFeedback";
+import { Button, Modal, ModalForm, type ModalFormHandle } from "@efcnewlife/newlife-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/src/pages/Content/LegalDocument/LegalDocumentDeleteForm.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDeleteForm.tsx
@@ -1,0 +1,30 @@
+import DeleteForm from "@/components/DataPage/DeleteForm";
+import { useTranslation } from "react-i18next";
+
+interface LegalDocumentDeleteFormProps {
+  onSubmit: (payload: { reason?: string; permanent?: boolean }) => Promise<void> | void;
+  onCancel: () => void;
+  submitting?: boolean;
+  isPermanent?: boolean;
+}
+
+const LegalDocumentDeleteForm = ({
+  onSubmit,
+  onCancel,
+  submitting,
+  isPermanent = false,
+}: LegalDocumentDeleteFormProps) => {
+  const { t } = useTranslation("content");
+  return (
+    <DeleteForm
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      submitting={submitting}
+      entityName={t("legalDocument.deleteForm.entityLabel")}
+      isPermanent={isPermanent}
+      softWarningBody={isPermanent ? undefined : t("legalDocument.deleteForm.publicReadWarning")}
+    />
+  );
+};
+
+export default LegalDocumentDeleteForm;

--- a/src/pages/Content/LegalDocument/legalDocumentForm.test.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   LEGAL_DOCUMENT_KINDS,
   LEGAL_DOCUMENT_PRODUCTS,
+  buildLegalDocumentCreatePayload,
   buildLegalDocumentUpdatePayload,
   createEmptyLegalDocumentTranslationMap,
   hydrateLegalDocumentTranslationMap,
   isLegalDocumentKind,
   isLegalDocumentProduct,
+  listLegalDocumentCatalogPairs,
 } from "./legalDocumentForm";
 
 describe("legal document catalog", () => {
@@ -22,6 +24,24 @@ describe("legal document catalog", () => {
     expect(isLegalDocumentKind("terms_of_service")).toBe(true);
     expect(isLegalDocumentKind("privacy_policy")).toBe(true);
     expect(isLegalDocumentKind("tos")).toBe(false);
+  });
+
+  it("lists every built-in Product x Kind pair for create", () => {
+    expect(listLegalDocumentCatalogPairs()).toEqual([
+      { product: "facility-booking", kind: "terms_of_service" },
+      { product: "facility-booking", kind: "privacy_policy" },
+      { product: "portal", kind: "terms_of_service" },
+      { product: "portal", kind: "privacy_policy" },
+    ]);
+  });
+
+  it("builds a create payload only for catalog Product and Kind", () => {
+    expect(buildLegalDocumentCreatePayload("portal", "privacy_policy")).toEqual({
+      product: "portal",
+      kind: "privacy_policy",
+    });
+    expect(buildLegalDocumentCreatePayload("unknown", "privacy_policy")).toBeNull();
+    expect(buildLegalDocumentCreatePayload("portal", "cookie_policy")).toBeNull();
   });
 });
 

--- a/src/pages/Content/LegalDocument/legalDocumentForm.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.ts
@@ -1,5 +1,9 @@
 import type { LocaleItem } from "@/api/services/localeService";
-import type { LegalDocumentTranslationItem, LegalDocumentUpdatePayload } from "@/api/services/legalDocumentService";
+import type {
+  LegalDocumentCreatePayload,
+  LegalDocumentTranslationItem,
+  LegalDocumentUpdatePayload,
+} from "@/api/services/legalDocumentService";
 
 export const LEGAL_DOCUMENT_PRODUCTS = ["facility-booking", "portal"] as const;
 export const LEGAL_DOCUMENT_KINDS = ["terms_of_service", "privacy_policy"] as const;
@@ -7,19 +11,34 @@ export const LEGAL_DOCUMENT_KINDS = ["terms_of_service", "privacy_policy"] as co
 export type LegalDocumentProduct = (typeof LEGAL_DOCUMENT_PRODUCTS)[number];
 export type LegalDocumentKind = (typeof LEGAL_DOCUMENT_KINDS)[number];
 
+export interface LegalDocumentCatalogPair {
+  product: LegalDocumentProduct;
+  kind: LegalDocumentKind;
+}
+
 export interface LegalDocumentTranslationFields {
   body: string;
 }
 
 export type LegalDocumentTranslationMap = Record<string, LegalDocumentTranslationFields>;
 
-export type { LegalDocumentTranslationItem, LegalDocumentUpdatePayload };
+export type { LegalDocumentCreatePayload, LegalDocumentTranslationItem, LegalDocumentUpdatePayload };
 
 export const isLegalDocumentProduct = (value: string): value is LegalDocumentProduct =>
   (LEGAL_DOCUMENT_PRODUCTS as readonly string[]).includes(value);
 
 export const isLegalDocumentKind = (value: string): value is LegalDocumentKind =>
   (LEGAL_DOCUMENT_KINDS as readonly string[]).includes(value);
+
+export const listLegalDocumentCatalogPairs = (): LegalDocumentCatalogPair[] =>
+  LEGAL_DOCUMENT_PRODUCTS.flatMap((product) => LEGAL_DOCUMENT_KINDS.map((kind) => ({ product, kind })));
+
+export const buildLegalDocumentCreatePayload = (product: string, kind: string): LegalDocumentCreatePayload | null => {
+  if (!isLegalDocumentProduct(product) || !isLegalDocumentKind(kind)) {
+    return null;
+  }
+  return { product, kind };
+};
 
 export const createEmptyLegalDocumentTranslationMap = (locales: LocaleItem[]): LegalDocumentTranslationMap =>
   locales.reduce<LegalDocumentTranslationMap>((acc, locale) => {

--- a/src/pages/Content/LegalDocument/legalDocumentForm.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.ts
@@ -1,9 +1,9 @@
-import type { LocaleItem } from "@/api/services/localeService";
 import type {
   LegalDocumentCreatePayload,
   LegalDocumentTranslationItem,
   LegalDocumentUpdatePayload,
 } from "@/api/services/legalDocumentService";
+import type { LocaleItem } from "@/api/services/localeService";
 
 export const LEGAL_DOCUMENT_PRODUCTS = ["facility-booking", "portal"] as const;
 export const LEGAL_DOCUMENT_KINDS = ["terms_of_service", "privacy_policy"] as const;

--- a/src/pages/Content/LegalDocument/legalDocumentSaveError.test.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentSaveError.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { ApiError } from "@/types/api";
+import { resolveLegalDocumentSaveErrorMessage } from "./legalDocumentSaveError";
+
+const t = (key: string): string => key;
+
+const apiError = (overrides: Partial<ApiError> & { details?: ApiError["details"] }): ApiError => ({
+  code: 409,
+  message: "Legal Document exists in recycle bin; restore it instead",
+  ...overrides,
+});
+
+describe("resolveLegalDocumentSaveErrorMessage", () => {
+  it("maps recycle-bin conflict to restore guidance", () => {
+    const error = apiError({
+      details: { error_code: "CONTENT_LEGAL_DOCUMENT_IN_RECYCLE_BIN" },
+    });
+    expect(resolveLegalDocumentSaveErrorMessage(error, t)).toBe("legalDocument.errors.inRecycleBin");
+  });
+
+  it("maps active-exists conflict to exists guidance", () => {
+    const error = apiError({
+      details: { error_code: "CONTENT_LEGAL_DOCUMENT_EXISTS" },
+    });
+    expect(resolveLegalDocumentSaveErrorMessage(error, t)).toBe("legalDocument.errors.exists");
+  });
+
+  it("maps not-found to notFound guidance", () => {
+    const error = apiError({
+      code: 404,
+      message: "Legal Document not found",
+      details: { error_code: "CONTENT_LEGAL_DOCUMENT_NOT_FOUND" },
+    });
+    expect(resolveLegalDocumentSaveErrorMessage(error, t)).toBe("legalDocument.errors.notFound");
+  });
+
+  it("returns undefined for unknown codes so callers keep the Operation fallback", () => {
+    const error = apiError({
+      details: { error_code: "CONTENT_FILE_NOT_FOUND" },
+    });
+    expect(resolveLegalDocumentSaveErrorMessage(error, t)).toBeUndefined();
+  });
+
+  it("returns undefined for non-ApiError values", () => {
+    expect(resolveLegalDocumentSaveErrorMessage(new Error("boom"), t)).toBeUndefined();
+  });
+});

--- a/src/pages/Content/LegalDocument/legalDocumentSaveError.test.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentSaveError.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { ApiError } from "@/types/api";
+import { describe, expect, it } from "vitest";
 import { resolveLegalDocumentSaveErrorMessage } from "./legalDocumentSaveError";
 
 const t = (key: string): string => key;

--- a/src/pages/Content/LegalDocument/legalDocumentSaveError.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentSaveError.ts
@@ -1,0 +1,31 @@
+import type { ApiError } from "@/types/api";
+
+export const LEGAL_DOCUMENT_ERROR_CODE = {
+  EXISTS: "CONTENT_LEGAL_DOCUMENT_EXISTS",
+  IN_RECYCLE_BIN: "CONTENT_LEGAL_DOCUMENT_IN_RECYCLE_BIN",
+  NOT_FOUND: "CONTENT_LEGAL_DOCUMENT_NOT_FOUND",
+} as const;
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+const isApiError = (error: unknown): error is ApiError =>
+  Boolean(error && typeof error === "object" && "code" in error && typeof (error as ApiError).code === "number");
+
+/** Maps Legal Document create/update `error_code` to content i18n keys (not raw backend detail). */
+export const resolveLegalDocumentSaveErrorMessage = (error: unknown, t: Translate): string | undefined => {
+  if (!isApiError(error)) {
+    return undefined;
+  }
+
+  const errorCode = typeof error.details?.error_code === "string" ? error.details.error_code : undefined;
+  if (errorCode === LEGAL_DOCUMENT_ERROR_CODE.IN_RECYCLE_BIN) {
+    return t("legalDocument.errors.inRecycleBin");
+  }
+  if (errorCode === LEGAL_DOCUMENT_ERROR_CODE.EXISTS) {
+    return t("legalDocument.errors.exists");
+  }
+  if (errorCode === LEGAL_DOCUMENT_ERROR_CODE.NOT_FOUND) {
+    return t("legalDocument.errors.notFound");
+  }
+  return undefined;
+};


### PR DESCRIPTION
## Summary

Adds Content Legal Document create (catalog Product × Kind only), soft-delete with public-read risk confirmation, recycle toggle, and restore on the admin DataPage. Maps create conflict `error_code` values to content i18n instead of raw backend detail. Fixes soft-delete request body shape for `httpClient.delete`.

Closes #47

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Reuses shared `DeleteForm` with optional `softWarningBody` for the public-read warning copy.
- Create form offers all built-in Product × Kind pairs; API rejects active or recycle conflicts with mapped Operation feedback.
- Recycle view follows Setting DataPage patterns (toggle, restore row action, optional permanent delete).

## Testing

- [x] `pnpm run format:check`
- [x] `pnpm run type-check`
- [x] `pnpm exec vitest run`

## Manual QA (recommended)

- [ ] Create a missing catalog Product × Kind row
- [ ] Create when pair is in recycle → mapped restore guidance toast
- [ ] Soft-delete shows public-read warning; row appears in recycle
- [ ] Restore from recycle view

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge


Made with [Cursor](https://cursor.com)