### PR TITLE
feat: Legal Document Effective Date UI and Context menu View

### DIFF
--- a/src/api/services/legalDocumentService.ts
+++ b/src/api/services/legalDocumentService.ts
@@ -8,9 +8,11 @@ export interface LegalDocumentTranslationItem {
 export interface LegalDocumentCreatePayload {
   product: string;
   kind: string;
+  effectiveDate: string;
 }
 
 export interface LegalDocumentUpdatePayload {
+  effectiveDate: string;
   translations: LegalDocumentTranslationItem[];
 }
 
@@ -18,6 +20,7 @@ export interface LegalDocumentItem {
   id: string;
   product: string;
   kind: string;
+  effectiveDate: string;
   createAt?: string | null;
   createdBy?: string | null;
   updateAt?: string | null;

--- a/src/i18n/locales/en/content.json
+++ b/src/i18n/locales/en/content.json
@@ -107,7 +107,8 @@
     "table": {
       "product": "Product",
       "kind": "Kind",
-      "updatedAt": "Updated"
+      "effectiveDate": "Effective Date",
+      "updatedAt": "Last Updated"
     },
     "product": {
       "facility-booking": "Facility Booking",
@@ -127,7 +128,8 @@
     },
     "modal": {
       "createTitle": "Create Legal Document",
-      "editTitle": "Edit Legal Document"
+      "editTitle": "Edit Legal Document",
+      "viewTitle": "View Legal Document"
     },
     "form": {
       "product": "Product",
@@ -136,9 +138,15 @@
       "kindPlaceholder": "Select a kind",
       "productRequired": "Product is required",
       "kindRequired": "Kind is required",
+      "effectiveDate": "Effective Date",
+      "effectiveDateRequired": "Effective Date is required",
+      "effectiveDateHint": "Calendar day when this wording takes effect. Saving the Markdown body alone does not change it.",
       "createHint": "Choose a built-in Product and Kind. Markdown is edited after create.",
       "body": "Markdown body",
       "bodyHint": "Markdown only. HTML and image embeds are not supported."
+    },
+    "view": {
+      "emptyBody": "No Markdown body for this locale yet."
     },
     "markdownEditor": {
       "modeEdit": "Edit",

--- a/src/i18n/locales/zh-CN/content.json
+++ b/src/i18n/locales/zh-CN/content.json
@@ -107,7 +107,8 @@
     "table": {
       "product": "产品",
       "kind": "类型",
-      "updatedAt": "更新时间"
+      "effectiveDate": "生效日",
+      "updatedAt": "最后更新"
     },
     "product": {
       "facility-booking": "场地预约",
@@ -127,7 +128,8 @@
     },
     "modal": {
       "createTitle": "新增法律文件",
-      "editTitle": "编辑法律文件"
+      "editTitle": "编辑法律文件",
+      "viewTitle": "查看法律文件"
     },
     "form": {
       "product": "产品",
@@ -136,9 +138,15 @@
       "kindPlaceholder": "选择类型",
       "productRequired": "请选择产品",
       "kindRequired": "请选择类型",
+      "effectiveDate": "生效日",
+      "effectiveDateRequired": "请选择生效日",
+      "effectiveDateHint": "此份文案开始生效的日历日。仅保存 Markdown 正文时不会自动变更。",
       "createHint": "仅能从内置产品与类型创建；Markdown 请在创建后编辑。",
       "body": "Markdown 内容",
       "bodyHint": "仅支持 Markdown，不支持 HTML 与图片嵌入。"
+    },
+    "view": {
+      "emptyBody": "此语言尚无 Markdown 内容。"
     },
     "markdownEditor": {
       "modeEdit": "编辑",

--- a/src/i18n/locales/zh-TW/content.json
+++ b/src/i18n/locales/zh-TW/content.json
@@ -107,7 +107,8 @@
     "table": {
       "product": "產品",
       "kind": "類型",
-      "updatedAt": "更新時間"
+      "effectiveDate": "生效日",
+      "updatedAt": "最後更新"
     },
     "product": {
       "facility-booking": "場地預約",
@@ -127,7 +128,8 @@
     },
     "modal": {
       "createTitle": "新增法律文件",
-      "editTitle": "編輯法律文件"
+      "editTitle": "編輯法律文件",
+      "viewTitle": "檢視法律文件"
     },
     "form": {
       "product": "產品",
@@ -136,9 +138,15 @@
       "kindPlaceholder": "選擇類型",
       "productRequired": "請選擇產品",
       "kindRequired": "請選擇類型",
+      "effectiveDate": "生效日",
+      "effectiveDateRequired": "請選擇生效日",
+      "effectiveDateHint": "此份文案開始生效的日曆日。僅儲存 Markdown 本文時不會自動變更。",
       "createHint": "僅能從內建產品與類型建立；Markdown 請於建立後編輯。",
       "body": "Markdown 內容",
       "bodyHint": "僅支援 Markdown，不支援 HTML 與圖片嵌入。"
+    },
+    "view": {
+      "emptyBody": "此語系尚無 Markdown 內容。"
     },
     "markdownEditor": {
       "modeEdit": "編輯",

--- a/src/pages/Content/LegalDocument/LegalDocumentCreateForm.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentCreateForm.tsx
@@ -1,3 +1,4 @@
+import { usePickerLabels } from "@/hooks/usePickerLabels";
 import {
   buildLegalDocumentCreatePayload,
   isLegalDocumentKind,
@@ -8,7 +9,9 @@ import {
   type LegalDocumentKind,
   type LegalDocumentProduct,
 } from "@/pages/Content/LegalDocument/legalDocumentForm";
-import { Select } from "@efcnewlife/newlife-ui";
+import { dayjsToApiDate } from "@/utils/dayjsApi";
+import { DatePicker, Select } from "@efcnewlife/newlife-ui";
+import type { Dayjs } from "dayjs";
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -20,9 +23,11 @@ export interface LegalDocumentCreateFormHandle {
 const LegalDocumentCreateForm = forwardRef<LegalDocumentCreateFormHandle>(
   function LegalDocumentCreateForm(_props, ref) {
     const { t } = useTranslation("content");
+    const pickerLabels = usePickerLabels();
     const [product, setProduct] = useState<LegalDocumentProduct | "">("");
     const [kind, setKind] = useState<LegalDocumentKind | "">("");
-    const [errors, setErrors] = useState<{ product?: string; kind?: string }>({});
+    const [effectiveDate, setEffectiveDate] = useState<Dayjs | null>(null);
+    const [errors, setErrors] = useState<{ product?: string; kind?: string; effectiveDate?: string }>({});
 
     const productOptions = LEGAL_DOCUMENT_PRODUCTS.map((value) => ({
       value,
@@ -36,19 +41,24 @@ const LegalDocumentCreateForm = forwardRef<LegalDocumentCreateFormHandle>(
 
     useImperativeHandle(ref, () => ({
       validate: () => {
-        const nextErrors: { product?: string; kind?: string } = {};
+        const nextErrors: { product?: string; kind?: string; effectiveDate?: string } = {};
         if (!product) {
           nextErrors.product = t("legalDocument.form.productRequired");
         }
         if (!kind) {
           nextErrors.kind = t("legalDocument.form.kindRequired");
         }
+        if (!effectiveDate) {
+          nextErrors.effectiveDate = t("legalDocument.form.effectiveDateRequired");
+        }
         setErrors(nextErrors);
         return Object.keys(nextErrors).length === 0;
       },
       getValues: () => {
-        if (!product || !kind) return null;
-        return buildLegalDocumentCreatePayload(product, kind);
+        if (!product || !kind || !effectiveDate) return null;
+        const dateValue = dayjsToApiDate(effectiveDate);
+        if (!dateValue) return null;
+        return buildLegalDocumentCreatePayload(product, kind, dateValue);
       },
     }));
 
@@ -80,6 +90,19 @@ const LegalDocumentCreateForm = forwardRef<LegalDocumentCreateFormHandle>(
           options={kindOptions}
           placeholder={t("legalDocument.form.kindPlaceholder")}
           error={errors.kind}
+        />
+        <DatePicker
+          id="legal-document-create-effective-date"
+          label={t("legalDocument.form.effectiveDate")}
+          value={effectiveDate}
+          onChange={(value) => {
+            setEffectiveDate(value);
+            setErrors((prev) => ({ ...prev, effectiveDate: undefined }));
+          }}
+          required
+          showTodayButton
+          labels={pickerLabels}
+          error={errors.effectiveDate}
         />
       </div>
     );

--- a/src/pages/Content/LegalDocument/LegalDocumentDataForm.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDataForm.tsx
@@ -1,19 +1,22 @@
 import type { LegalDocumentDetail, LegalDocumentUpdatePayload } from "@/api/services/legalDocumentService";
 import { useActiveLocales } from "@/hooks/useActiveLocales";
+import { usePickerLabels } from "@/hooks/usePickerLabels";
 import {
   buildLegalDocumentUpdatePayload,
   hydrateLegalDocumentTranslationMap,
   type LegalDocumentTranslationMap,
 } from "@/pages/Content/LegalDocument/legalDocumentForm";
 import { buildLegalDocumentMarkdownEditorLabels } from "@/pages/Content/LegalDocument/legalDocumentMarkdownEditorLabels";
+import { apiDateToDayjs, dayjsToApiDate } from "@/utils/dayjsApi";
 import { localeTabLabel } from "@/utils/translationForm";
-import { MarkdownEditor, Tabs } from "@efcnewlife/newlife-ui";
+import { DatePicker, MarkdownEditor, Tabs } from "@efcnewlife/newlife-ui";
+import type { Dayjs } from "dayjs";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export interface LegalDocumentDataFormHandle {
   validate: () => boolean;
-  getValues: () => LegalDocumentUpdatePayload;
+  getValues: () => LegalDocumentUpdatePayload | null;
 }
 
 interface LegalDocumentDataFormProps {
@@ -24,15 +27,18 @@ const LegalDocumentDataForm = forwardRef<LegalDocumentDataFormHandle, LegalDocum
   function LegalDocumentDataForm({ document }, ref) {
     const { t } = useTranslation("content");
     const { t: tCommon } = useTranslation("common");
+    const pickerLabels = usePickerLabels();
     const { locales, defaultLocaleId, loading, error } = useActiveLocales();
 
     const [translationMap, setTranslationMap] = useState<LegalDocumentTranslationMap>({});
+    const [effectiveDate, setEffectiveDate] = useState<Dayjs | null>(null);
     const [activeTab, setActiveTab] = useState("");
-    const [errors, setErrors] = useState<{ body?: string }>({});
+    const [errors, setErrors] = useState<{ body?: string; effectiveDate?: string }>({});
 
     useEffect(() => {
       if (locales.length === 0) return;
       setTranslationMap(hydrateLegalDocumentTranslationMap(locales, document.translations));
+      setEffectiveDate(apiDateToDayjs(document.effectiveDate));
       setActiveTab(defaultLocaleId || locales[0]?.id || "");
       setErrors({});
     }, [document, defaultLocaleId, locales]);
@@ -47,17 +53,24 @@ const LegalDocumentDataForm = forwardRef<LegalDocumentDataFormHandle, LegalDocum
     );
 
     const validate = (): boolean => {
+      const nextErrors: { body?: string; effectiveDate?: string } = {};
       if (!defaultLocaleId) {
-        setErrors({ body: tCommon("translation.defaultLocaleRequired") });
-        return false;
+        nextErrors.body = tCommon("translation.defaultLocaleRequired");
       }
-      setErrors({});
-      return true;
+      if (!effectiveDate) {
+        nextErrors.effectiveDate = t("legalDocument.form.effectiveDateRequired");
+      }
+      setErrors(nextErrors);
+      return Object.keys(nextErrors).length === 0;
     };
 
     useImperativeHandle(ref, () => ({
       validate,
-      getValues: () => buildLegalDocumentUpdatePayload(translationMap),
+      getValues: () => {
+        const dateValue = dayjsToApiDate(effectiveDate);
+        if (!dateValue) return null;
+        return buildLegalDocumentUpdatePayload(translationMap, dateValue);
+      },
     }));
 
     const activeBody = translationMap[activeTab]?.body ?? "";
@@ -79,6 +92,23 @@ const LegalDocumentDataForm = forwardRef<LegalDocumentDataFormHandle, LegalDocum
             </dd>
           </div>
         </dl>
+
+        <div className="space-y-1.5">
+          <DatePicker
+            id="legal-document-edit-effective-date"
+            label={t("legalDocument.form.effectiveDate")}
+            value={effectiveDate}
+            onChange={(value) => {
+              setEffectiveDate(value);
+              setErrors((prev) => ({ ...prev, effectiveDate: undefined }));
+            }}
+            required
+            showTodayButton
+            labels={pickerLabels}
+            error={errors.effectiveDate}
+          />
+          <p className="text-sm text-gray-500 dark:text-gray-400">{t("legalDocument.form.effectiveDateHint")}</p>
+        </div>
 
         {loading ? <p className="text-sm text-gray-500">{tCommon("loading")}</p> : null}
         {error ? <p className="text-sm text-error-500">{error}</p> : null}

--- a/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDataPage.tsx
@@ -15,6 +15,7 @@ import LegalDocumentDataForm, {
   type LegalDocumentDataFormHandle,
 } from "@/pages/Content/LegalDocument/LegalDocumentDataForm";
 import LegalDocumentDeleteForm from "@/pages/Content/LegalDocument/LegalDocumentDeleteForm";
+import LegalDocumentDetailView from "@/pages/Content/LegalDocument/LegalDocumentDetailView";
 import { isLegalDocumentKind, isLegalDocumentProduct } from "@/pages/Content/LegalDocument/legalDocumentForm";
 import { resolveLegalDocumentSaveErrorMessage } from "@/pages/Content/LegalDocument/legalDocumentSaveError";
 import LegalDocumentSearchPopover, {
@@ -43,10 +44,12 @@ const LegalDocumentDataPage = () => {
   const [appliedFilters, setAppliedFilters] = useState<LegalDocumentSearchFilters>({});
   const [formMode, setFormMode] = useState<"create" | "edit">("create");
   const [editing, setEditing] = useState<LegalDocumentDetail | null>(null);
+  const [viewing, setViewing] = useState<LegalDocumentDetail | null>(null);
   const [deleting, setDeleting] = useState<LegalDocumentRow | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const { isOpen: isFormOpen, openModal: openFormModal, closeModal: closeFormModal } = useModal(false);
+  const { isOpen: isViewOpen, openModal: openViewModal, closeModal: closeViewModal } = useModal(false);
   const { isOpen: isDeleteOpen, openModal: openDeleteModal, closeModal: closeDeleteModal } = useModal(false);
   const editFormRef = useRef<LegalDocumentDataFormHandle>(null);
   const createFormRef = useRef<LegalDocumentCreateFormHandle>(null);
@@ -109,6 +112,13 @@ const LegalDocumentDataPage = () => {
         sortable: true,
         width: "w-48",
         render: (value) => kindLabel(String(value || "")),
+      },
+      {
+        key: "effectiveDate",
+        label: t("legalDocument.table.effectiveDate"),
+        sortable: true,
+        width: "w-40",
+        render: (value) => (value ? DateUtil.format(value as string, "YYYY-MM-DD") : "—"),
       },
       {
         key: "updateAt",
@@ -187,28 +197,43 @@ const LegalDocumentDataPage = () => {
     ];
   }, [fetchPages, openFormModal, searchFilters, showDeleted, t]);
 
+  const openDetailModal = useCallback(
+    async (row: LegalDocumentRow, mode: "view" | "edit") => {
+      try {
+        const res = await legalDocumentService.getById(row.id);
+        if (res.success) {
+          if (mode === "view") {
+            setViewing(res.data);
+            openViewModal();
+          } else {
+            setFormMode("edit");
+            setEditing(res.data);
+            openFormModal();
+          }
+        } else {
+          notifyApiError(
+            { code: 400, message: "" },
+            { title: t("common:feedback.loadFailed"), fallbackDescription: t("common:feedback.loadFailedDesc") }
+          );
+        }
+      } catch (error) {
+        notifyApiError(error, {
+          title: t("common:feedback.loadFailed"),
+          fallbackDescription: t("common:feedback.loadFailedDesc"),
+        });
+      }
+    },
+    [openFormModal, openViewModal, t]
+  );
+
   const rowActions: MenuButtonType<LegalDocumentRow>[] = useMemo(
     () => [
+      CommonRowAction.VIEW((row) => {
+        void openDetailModal(row, "view");
+      }),
       CommonRowAction.EDIT(
-        async (row) => {
-          try {
-            const res = await legalDocumentService.getById(row.id);
-            if (res.success) {
-              setFormMode("edit");
-              setEditing(res.data);
-              openFormModal();
-            } else {
-              notifyApiError(
-                { code: 400, message: "" },
-                { title: t("common:feedback.loadFailed"), fallbackDescription: t("common:feedback.loadFailedDesc") }
-              );
-            }
-          } catch (error) {
-            notifyApiError(error, {
-              title: t("common:feedback.loadFailed"),
-              fallbackDescription: t("common:feedback.loadFailedDesc"),
-            });
-          }
+        (row) => {
+          void openDetailModal(row, "edit");
         },
         { visible: () => !showDeleted }
       ),
@@ -243,13 +268,18 @@ const LegalDocumentDataPage = () => {
         }
       ),
     ],
-    [fetchPages, openDeleteModal, openFormModal, showDeleted, t]
+    [fetchPages, openDeleteModal, openDetailModal, showDeleted, t]
   );
 
   const closeForm = () => {
     closeFormModal();
     setEditing(null);
     setFormMode("create");
+  };
+
+  const closeView = () => {
+    closeViewModal();
+    setViewing(null);
   };
 
   return (
@@ -324,6 +354,7 @@ const LegalDocumentDataPage = () => {
 
           if (!editing?.id || !editFormRef.current?.validate()) return;
           const values = editFormRef.current.getValues();
+          if (!values) return;
           setSubmitting(true);
           try {
             await legalDocumentService.update(editing.id, values);
@@ -348,6 +379,15 @@ const LegalDocumentDataPage = () => {
           <LegalDocumentDataForm ref={editFormRef} document={editing} />
         ) : null}
       </ModalForm>
+
+      <Modal
+        title={t("legalDocument.modal.viewTitle")}
+        isOpen={isViewOpen}
+        onClose={closeView}
+        className="max-w-5xl w-full mx-4 p-6 min-h-0 max-h-[90vh] overflow-y-auto"
+      >
+        {viewing ? <LegalDocumentDetailView document={viewing} /> : null}
+      </Modal>
 
       <Modal
         isOpen={isDeleteOpen}

--- a/src/pages/Content/LegalDocument/LegalDocumentDetailView.tsx
+++ b/src/pages/Content/LegalDocument/LegalDocumentDetailView.tsx
@@ -1,0 +1,94 @@
+import type { LegalDocumentDetail } from "@/api/services/legalDocumentService";
+import { useActiveLocales } from "@/hooks/useActiveLocales";
+import { isLegalDocumentBodyEmpty } from "@/pages/Content/LegalDocument/legalDocumentForm";
+import { DateUtil } from "@/utils/dateUtil";
+import { localeTabLabel } from "@/utils/translationForm";
+import { MarkdownPreview, Tabs } from "@efcnewlife/newlife-ui";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface LegalDocumentDetailViewProps {
+  document: LegalDocumentDetail;
+}
+
+const LegalDocumentDetailView = ({ document }: LegalDocumentDetailViewProps) => {
+  const { t } = useTranslation("content");
+  const { t: tCommon } = useTranslation("common");
+  const { locales, defaultLocaleId, loading, error } = useActiveLocales();
+  const [activeTab, setActiveTab] = useState("");
+
+  useEffect(() => {
+    if (locales.length === 0) return;
+    setActiveTab(defaultLocaleId || locales[0]?.id || "");
+  }, [defaultLocaleId, locales]);
+
+  const tabs = useMemo(
+    () =>
+      locales.map((locale) => ({
+        value: locale.id,
+        label: localeTabLabel(locale, locale.id === defaultLocaleId),
+      })),
+    [locales, defaultLocaleId]
+  );
+
+  const bodyByLocaleId = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const item of document.translations || []) {
+      map[item.localeId] = item.body ?? "";
+    }
+    return map;
+  }, [document.translations]);
+
+  const activeBody = bodyByLocaleId[activeTab] ?? "";
+
+  return (
+    <div className="space-y-4">
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+        <div>
+          <dt className="text-gray-500 dark:text-gray-400">{t("legalDocument.form.product")}</dt>
+          <dd className="mt-1 font-medium text-gray-800 dark:text-white/90">
+            {t(`legalDocument.product.${document.product}`, { defaultValue: document.product })}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-500 dark:text-gray-400">{t("legalDocument.form.kind")}</dt>
+          <dd className="mt-1 font-medium text-gray-800 dark:text-white/90">
+            {t(`legalDocument.kind.${document.kind}`, { defaultValue: document.kind })}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-500 dark:text-gray-400">{t("legalDocument.form.effectiveDate")}</dt>
+          <dd className="mt-1 font-medium text-gray-800 dark:text-white/90">
+            {document.effectiveDate ? DateUtil.format(document.effectiveDate, "YYYY-MM-DD") : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-500 dark:text-gray-400">{t("legalDocument.table.updatedAt")}</dt>
+          <dd className="mt-1 font-medium text-gray-800 dark:text-white/90">
+            {document.updateAt ? DateUtil.format(document.updateAt) : "—"}
+          </dd>
+        </div>
+      </dl>
+
+      {loading ? <p className="text-sm text-gray-500">{tCommon("loading")}</p> : null}
+      {error ? <p className="text-sm text-error-500">{error}</p> : null}
+
+      {!loading && !error && locales.length > 0 ? (
+        <div className="space-y-3">
+          <Tabs tabs={tabs} value={activeTab} onChange={setActiveTab} label={tCommon("translation.tabsLabel")} />
+          {isLegalDocumentBodyEmpty(activeBody) ? (
+            <p className="rounded-lg border border-gray-200 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              {t("legalDocument.view.emptyBody")}
+            </p>
+          ) : (
+            <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700 max-h-[50vh] overflow-y-auto">
+              <MarkdownPreview value={activeBody} profile="legal" />
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default LegalDocumentDetailView;

--- a/src/pages/Content/LegalDocument/legalDocumentForm.test.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.test.ts
@@ -6,6 +6,8 @@ import {
   buildLegalDocumentUpdatePayload,
   createEmptyLegalDocumentTranslationMap,
   hydrateLegalDocumentTranslationMap,
+  isLegalDocumentBodyEmpty,
+  isLegalDocumentEffectiveDate,
   isLegalDocumentKind,
   isLegalDocumentProduct,
   listLegalDocumentCatalogPairs,
@@ -35,13 +37,34 @@ describe("legal document catalog", () => {
     ]);
   });
 
-  it("builds a create payload only for catalog Product and Kind", () => {
-    expect(buildLegalDocumentCreatePayload("portal", "privacy_policy")).toEqual({
+  it("builds a create payload only for catalog Product, Kind, and Effective Date", () => {
+    expect(buildLegalDocumentCreatePayload("portal", "privacy_policy", "2026-01-15")).toEqual({
       product: "portal",
       kind: "privacy_policy",
+      effectiveDate: "2026-01-15",
     });
-    expect(buildLegalDocumentCreatePayload("unknown", "privacy_policy")).toBeNull();
-    expect(buildLegalDocumentCreatePayload("portal", "cookie_policy")).toBeNull();
+    expect(buildLegalDocumentCreatePayload("unknown", "privacy_policy", "2026-01-15")).toBeNull();
+    expect(buildLegalDocumentCreatePayload("portal", "cookie_policy", "2026-01-15")).toBeNull();
+    expect(buildLegalDocumentCreatePayload("portal", "privacy_policy", "")).toBeNull();
+    expect(buildLegalDocumentCreatePayload("portal", "privacy_policy", "01/15/2026")).toBeNull();
+  });
+});
+
+describe("legal document Effective Date", () => {
+  it("accepts only YYYY-MM-DD calendar days", () => {
+    expect(isLegalDocumentEffectiveDate("2026-01-15")).toBe(true);
+    expect(isLegalDocumentEffectiveDate("2026-1-15")).toBe(false);
+    expect(isLegalDocumentEffectiveDate("")).toBe(false);
+    expect(isLegalDocumentEffectiveDate("not-a-date")).toBe(false);
+  });
+});
+
+describe("legal document View body", () => {
+  it("treats blank and whitespace-only Markdown as empty", () => {
+    expect(isLegalDocumentBodyEmpty("")).toBe(true);
+    expect(isLegalDocumentBodyEmpty("   \n\t")).toBe(true);
+    expect(isLegalDocumentBodyEmpty(undefined)).toBe(true);
+    expect(isLegalDocumentBodyEmpty("# Terms")).toBe(false);
   });
 });
 
@@ -83,17 +106,27 @@ describe("legal document translation map", () => {
     });
   });
 
-  it("builds an update payload for every locale, including empty Markdown bodies", () => {
-    const payload = buildLegalDocumentUpdatePayload({
-      "locale-en": { body: "  Hello  " },
-      "locale-tw": { body: "" },
-    });
+  it("builds an update payload with Effective Date and every locale body", () => {
+    const payload = buildLegalDocumentUpdatePayload(
+      {
+        "locale-en": { body: "  Hello  " },
+        "locale-tw": { body: "" },
+      },
+      "2026-03-01"
+    );
 
     expect(payload).toEqual({
+      effectiveDate: "2026-03-01",
       translations: [
         { localeId: "locale-en", body: "  Hello  " },
         { localeId: "locale-tw", body: "" },
       ],
     });
+  });
+
+  it("returns null update payload when Effective Date is missing or invalid", () => {
+    const map = { "locale-en": { body: "Hello" } };
+    expect(buildLegalDocumentUpdatePayload(map, "")).toBeNull();
+    expect(buildLegalDocumentUpdatePayload(map, "03/01/2026")).toBeNull();
   });
 });

--- a/src/pages/Content/LegalDocument/legalDocumentForm.ts
+++ b/src/pages/Content/LegalDocument/legalDocumentForm.ts
@@ -8,6 +8,8 @@ import type { LocaleItem } from "@/api/services/localeService";
 export const LEGAL_DOCUMENT_PRODUCTS = ["facility-booking", "portal"] as const;
 export const LEGAL_DOCUMENT_KINDS = ["terms_of_service", "privacy_policy"] as const;
 
+const EFFECTIVE_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 export type LegalDocumentProduct = (typeof LEGAL_DOCUMENT_PRODUCTS)[number];
 export type LegalDocumentKind = (typeof LEGAL_DOCUMENT_KINDS)[number];
 
@@ -30,14 +32,22 @@ export const isLegalDocumentProduct = (value: string): value is LegalDocumentPro
 export const isLegalDocumentKind = (value: string): value is LegalDocumentKind =>
   (LEGAL_DOCUMENT_KINDS as readonly string[]).includes(value);
 
+export const isLegalDocumentEffectiveDate = (value: string): boolean => EFFECTIVE_DATE_PATTERN.test(value);
+
+export const isLegalDocumentBodyEmpty = (body: string | null | undefined): boolean => !(body ?? "").trim();
+
 export const listLegalDocumentCatalogPairs = (): LegalDocumentCatalogPair[] =>
   LEGAL_DOCUMENT_PRODUCTS.flatMap((product) => LEGAL_DOCUMENT_KINDS.map((kind) => ({ product, kind })));
 
-export const buildLegalDocumentCreatePayload = (product: string, kind: string): LegalDocumentCreatePayload | null => {
-  if (!isLegalDocumentProduct(product) || !isLegalDocumentKind(kind)) {
+export const buildLegalDocumentCreatePayload = (
+  product: string,
+  kind: string,
+  effectiveDate: string
+): LegalDocumentCreatePayload | null => {
+  if (!isLegalDocumentProduct(product) || !isLegalDocumentKind(kind) || !isLegalDocumentEffectiveDate(effectiveDate)) {
     return null;
   }
-  return { product, kind };
+  return { product, kind, effectiveDate };
 };
 
 export const createEmptyLegalDocumentTranslationMap = (locales: LocaleItem[]): LegalDocumentTranslationMap =>
@@ -61,9 +71,18 @@ export const hydrateLegalDocumentTranslationMap = (
   return map;
 };
 
-export const buildLegalDocumentUpdatePayload = (map: LegalDocumentTranslationMap): LegalDocumentUpdatePayload => ({
-  translations: Object.entries(map).map(([localeId, fields]) => ({
-    localeId,
-    body: fields.body ?? "",
-  })),
-});
+export const buildLegalDocumentUpdatePayload = (
+  map: LegalDocumentTranslationMap,
+  effectiveDate: string
+): LegalDocumentUpdatePayload | null => {
+  if (!isLegalDocumentEffectiveDate(effectiveDate)) {
+    return null;
+  }
+  return {
+    effectiveDate,
+    translations: Object.entries(map).map(([localeId, fields]) => ({
+      localeId,
+      body: fields.body ?? "",
+    })),
+  };
+};


### PR DESCRIPTION
## Summary

Operators can set a required Effective Date on Legal Document create/edit, see Effective Date and Last Updated on the list, and open a read-only Context menu View with metadata, locale Tabs, and MarkdownPreview (`legal`) or empty-body copy. View stays available for soft-deleted rows (Read); Edit remains hidden in recycle.

Closes #53

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Consumes Core API `effectiveDate` on create/update/list/detail (camelCase responses; snake_case via `httpClient`).
- Companion API for recycle View detail: https://github.com/efcnewlife/newlife-core-api/pull/102 (merge API first or with this PR).
- Does not rework MarkdownEditor install (#51).

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] Manual: create with Effective Date; edit date independently of body; list columns; View (active + deleted)

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge