### PR TITLE
feat: remove unused facility policy-settings API client

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -189,11 +189,6 @@ export const API_ENDPOINTS = {
       UPDATE: (id: string) => `${ADMIN_API_PREFIX}/facility/surcharges/${id}`,
       DELETE: (id: string) => `${ADMIN_API_PREFIX}/facility/surcharges/${id}`,
     },
-    POLICY_SETTINGS: {
-      LIST: `${ADMIN_API_PREFIX}/facility/policy-settings`,
-      DETAIL: (id: string) => `${ADMIN_API_PREFIX}/facility/policy-settings/${id}`,
-      UPDATE: (id: string) => `${ADMIN_API_PREFIX}/facility/policy-settings/${id}`,
-    },
     BOOKINGS: {
       PAGES: `${ADMIN_API_PREFIX}/facility/bookings/pages`,
       RANGE: `${ADMIN_API_PREFIX}/facility/bookings/range`,

--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -293,23 +293,6 @@ export interface SurchargeWrite {
   remark?: string;
 }
 
-export interface PolicySettingItem {
-  id: string;
-  settingKey: string;
-  facilityId?: string;
-  amount: string | number;
-  currency: string;
-  isActive: boolean;
-  createAt?: string;
-  updateAt?: string;
-}
-
-export interface PolicySettingUpdate {
-  amount: string | number;
-  currency?: string;
-  isActive?: boolean;
-}
-
 // Booking
 export interface BookingPagesParams extends PagesParams {
   facilityId?: string;
@@ -720,22 +703,6 @@ class FacilityService {
       url: API_ENDPOINTS.FACILITY.SURCHARGES.DELETE(id),
       data: payload,
     });
-  }
-
-  // Policy settings
-  async listPolicySettings(facilityId?: string): Promise<ApiResponse<{ items: PolicySettingItem[] }>> {
-    if (IS_MOCK_API) return emptyList();
-    return httpClient.get(API_ENDPOINTS.FACILITY.POLICY_SETTINGS.LIST, facilityId ? { facilityId } : undefined);
-  }
-
-  async getPolicySetting(id: string): Promise<ApiResponse<PolicySettingItem>> {
-    if (IS_MOCK_API) return { success: true, data: {} as PolicySettingItem };
-    return httpClient.get(API_ENDPOINTS.FACILITY.POLICY_SETTINGS.DETAIL(id));
-  }
-
-  async updatePolicySetting(id: string, payload: PolicySettingUpdate): Promise<ApiResponse<void>> {
-    if (IS_MOCK_API) return { success: true, data: undefined as void };
-    return httpClient.put(API_ENDPOINTS.FACILITY.POLICY_SETTINGS.UPDATE(id), payload);
   }
 
   // Bookings


### PR DESCRIPTION
## Summary

Strip the unused facility policy-settings API client so the admin SPA no longer points at Rental Policy Setting endpoints after that catalog is removed. There is no Policy Settings admin page; this change is endpoint config, types, and `facilityService` methods only.

Closes #56

Companion: efcnewlife/newlife-core-api#127 (can land independently; nothing in the UI called these methods).

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [x] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Removed `API_ENDPOINTS.FACILITY.POLICY_SETTINGS` (`list` / `detail` / `update`).
- Removed `PolicySettingItem`, `PolicySettingUpdate`, and `listPolicySettings` / `getPolicySetting` / `updatePolicySetting` from `facilityService`.
- No remaining `policy-settings` / `PolicySetting` references under `src/`.

## Testing

- [x] `pnpm run format:check`
- [x] `pnpm run type-check`
- [x] `pnpm run test`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)